### PR TITLE
Experiment with requiring type applications

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,3 @@
 packages: .
 package witch
-  ghc-options: -Werror
   tests: true

--- a/src/lib/Witch.hs
+++ b/src/lib/Witch.hs
@@ -1,4 +1,6 @@
 {-# language AllowAmbiguousTypes #-}
+{-# language ConstraintKinds #-}
+{-# language DataKinds #-}
 {-# language DefaultSignatures #-}
 {-# language FlexibleInstances #-}
 {-# language MultiParamTypeClasses #-}
@@ -50,6 +52,7 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Tuple as Tuple
+import qualified Data.Type.Equality as Type
 import qualified Data.Void as Void
 import qualified Data.Word as Word
 import qualified Numeric.Natural as Natural
@@ -125,18 +128,15 @@ class Cast source target where
   default cast :: Coerce.Coercible source target => source -> target
   cast = Coerce.coerce
 
--- https://twitter.com/BanjoTragedy/status/1329091174305447938
-type family Ambiguous a where
-  Ambiguous Void.Void = ()
-  Ambiguous a = a
+type Ambiguous a b = (Type.==) a b ~ 'True
 
 -- | TODO
-from :: forall s target source . (Ambiguous s ~ source, Cast source target) => source -> target
+from :: forall s target source . (Ambiguous s source, Cast source target) => source -> target
 from = cast
 
 -- | This function converts a value from one type into another. This is the
 -- same as 'cast' except that the type variables are in the opposite order.
-into :: forall t source target . (Ambiguous t ~ target, Cast source target) => source -> target
+into :: forall t source target . (Ambiguous t target, Cast source target) => source -> target
 into = cast
 
 -- | This function converts a value from one type into another by going through

--- a/src/lib/Witch.hs
+++ b/src/lib/Witch.hs
@@ -1,6 +1,4 @@
 {-# language AllowAmbiguousTypes #-}
-{-# language ConstraintKinds #-}
-{-# language DataKinds #-}
 {-# language DefaultSignatures #-}
 {-# language FlexibleInstances #-}
 {-# language MultiParamTypeClasses #-}
@@ -52,7 +50,6 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Tuple as Tuple
-import qualified Data.Type.Equality as Type
 import qualified Data.Void as Void
 import qualified Data.Word as Word
 import qualified Numeric.Natural as Natural
@@ -128,15 +125,18 @@ class Cast source target where
   default cast :: Coerce.Coercible source target => source -> target
   cast = Coerce.coerce
 
-type Ambiguous a b = (Type.==) a b ~ 'True
+-- https://twitter.com/BanjoTragedy/status/1329091174305447938
+type family Ambiguous a where
+  Ambiguous Void.Void = ()
+  Ambiguous a = a
 
 -- | TODO
-from :: forall s target source . (Ambiguous s source, Cast source target) => source -> target
+from :: forall s target source . (Ambiguous s ~ source, Cast source target) => source -> target
 from = cast
 
 -- | This function converts a value from one type into another. This is the
 -- same as 'cast' except that the type variables are in the opposite order.
-into :: forall t source target . (Ambiguous t target, Cast source target) => source -> target
+into :: forall t source target . (Ambiguous t ~ target, Cast source target) => source -> target
 into = cast
 
 -- | This function converts a value from one type into another by going through

--- a/witch.cabal
+++ b/witch.cabal
@@ -26,6 +26,7 @@ library
   ghc-options:
     -Weverything
     -Wno-implicit-prelude
+    -Wno-redundant-constraints
     -Wno-safe
     -Wno-unsafe
   hs-source-dirs: src/lib


### PR DESCRIPTION
I want to require type applications when using `from` and `into`. My rationale is that a lone `from` or `into` can be confusing. Which types is it converting between? This is especially bad in a pipeline: `from . from . from ...`

This pull request adds an ambiguous type family that forces you to add a type application for the first type variable of both `from` and `into`. Note that `via` already requires a type application because the `through` type is ambiguous. 

This trick didn't play nicely with the type class method, so I changed `from` from a method to a function. I renamed the existing `From` type class to `Cast` (and its corresponding method from `from` to `cast`). I didn't really want to do this, but perhaps it's better; the type signature for `into` is perhaps less confusing now. 

I would prefer to have a custom type error for this that suggests using type applications, but I don't know how to do that (or even if it's possible). 

``` hs
-- cast does not require a type application
>>> cast 'a' :: Int
97

-- from now requires a type application
>>> from 'a' :: Int
<interactive>:1:1: error:
    • Couldn't match type ‘Ambiguous s0’ with ‘Char’
        arising from a use of ‘from’
      The type variable ‘s0’ is ambiguous
    • In the expression: from 'a' :: Int
      In an equation for ‘it’: it = from 'a' :: Int
>>> from @Char 'a' :: Int
97

-- so does into
>>> into 'a' :: Int
<interactive>:3:1: error:
    • Couldn't match type ‘Ambiguous t0’ with ‘Int’
        arising from a use of ‘into’
      The type variable ‘t0’ is ambiguous
    • In the expression: into 'a' :: Int
      In an equation for ‘it’: it = into 'a' :: Int
>>> into @Int 'a' :: Int
97

-- via still requires a type application
>>> via 'a' :: Integer
<interactive>:5:1: error:
    • Ambiguous type variable ‘through0’ arising from a use of ‘via’
      prevents the constraint ‘(Cast
                                  through0 Integer)’ from being solved.
      Probable fix: use a type annotation to specify what ‘through0’ should be.
      These potential instances exist:
        instance Cast a a
          -- Defined at /home/taylor/Documents/GitHub/tfausak/witch/src/lib/Witch.hs:154:10
        instance Cast Void.Void x
          -- Defined at /home/taylor/Documents/GitHub/tfausak/witch/src/lib/Witch.hs:178:10
        instance Cast Natural.Natural Integer
          -- Defined at /home/taylor/Documents/GitHub/tfausak/witch/src/lib/Witch.hs:214:10
        ...plus three others
        (use -fprint-potential-instances to see them all)
    • In the expression: via 'a' :: Integer
      In an equation for ‘it’: it = via 'a' :: Integer
>>> via @Int 'a' :: Integer
97
```