### PR TITLE
Use type applications for showing try cast exceptions

### DIFF
--- a/src/lib/Witch/TryCastException.hs
+++ b/src/lib/Witch/TryCastException.hs
@@ -22,10 +22,11 @@ instance
   ) => Show (TryCastException source target) where
   showsPrec d (TryCastException x e) =
     showParen (d > 10)
-      $ showString "TryCastException {- "
-      . shows
-          (Typeable.typeRep (Proxy.Proxy :: Proxy.Proxy (source -> target)))
-      . showString " -} "
+      $ showString "TryCastException @"
+      . showsPrec 11 (Typeable.typeRep (Proxy.Proxy :: Proxy.Proxy source))
+      . showString " @"
+      . showsPrec 11 (Typeable.typeRep (Proxy.Proxy :: Proxy.Proxy target))
+      . showChar ' '
       . showsPrec 11 x
       . showChar ' '
       . showsPrec 11 e

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -1643,16 +1643,17 @@ main = Hspec.hspec . Hspec.describe "Witch" $ do
       Hspec.it "needs tests" Hspec.pending
 
     Hspec.describe "Cast (TryCastException s t) String" $ do
+      test $ Witch.cast (Witch.TryCastException Nothing Nothing :: Witch.TryCastException (Maybe Bool) (Maybe Int)) `Hspec.shouldBe` "TryCastException @(Maybe Bool) @(Maybe Int) Nothing Nothing"
       let f = Witch.cast @(Witch.TryCastException Bool Int) @String
-      test $ f (Witch.TryCastException False Nothing) `Hspec.shouldBe` "TryCastException {- Bool -> Int -} False Nothing"
+      test $ f (Witch.TryCastException False Nothing) `Hspec.shouldBe` "TryCastException @Bool @Int False Nothing"
 
     Hspec.describe "Cast (TryCastException s t) Text" $ do
       let f = Witch.cast @(Witch.TryCastException Bool Int) @Text.Text
-      test $ f (Witch.TryCastException False Nothing) `Hspec.shouldBe` Text.pack "TryCastException {- Bool -> Int -} False Nothing"
+      test $ f (Witch.TryCastException False Nothing) `Hspec.shouldBe` Text.pack "TryCastException @Bool @Int False Nothing"
 
     Hspec.describe "Cast (TryCastException s t) LazyText" $ do
       let f = Witch.cast @(Witch.TryCastException Bool Int) @LazyText.Text
-      test $ f (Witch.TryCastException False Nothing) `Hspec.shouldBe` LazyText.pack "TryCastException {- Bool -> Int -} False Nothing"
+      test $ f (Witch.TryCastException False Nothing) `Hspec.shouldBe` LazyText.pack "TryCastException @Bool @Int False Nothing"
 
 test :: Hspec.Example a => a -> Hspec.SpecWith (Hspec.Arg a)
 test = Hspec.it ""


### PR DESCRIPTION
Before:

``` hs
TryCastException {- s -> t -} x e
```

After:

``` hs
TryCastException @s @t x e
```

This allows you to copy-paste the output of `show` and have it type check without being ambiguous. Also it's shorter, which is nice. 