### PR TITLE
Add `withSource` and `withTarget` helpers

### DIFF
--- a/src/lib/Witch/Instances.hs
+++ b/src/lib/Witch/Instances.hs
@@ -1141,8 +1141,8 @@ instance From.From String LazyByteString.ByteString where
 
 -- | Uses @coerce@.
 instance From.From
-  (TryFromException.TryFromException s u)
-  (TryFromException.TryFromException s t)
+  (TryFromException.TryFromException source oldTarget)
+  (TryFromException.TryFromException source newTarget)
 
 -- Day
 


### PR DESCRIPTION
These come from #38. 

For the time being I have chosen not to expose them from the top level `Witch` module. I think that in general people don't really need to use these functions. Using `eitherTryFrom` and `tryVia` ought to be enough. But they're handy functions that should be easily importable by anyone that needs them. 