### PR TITLE
Change UTF-8 instances. 

### DIFF
--- a/source/library/Witch.hs
+++ b/source/library/Witch.hs
@@ -22,6 +22,9 @@ module Witch
     -- * Data types
     Witch.TryFromException.TryFromException (..),
 
+    -- ** Encodings
+    Witch.Encoding.Utf8,
+
     -- * Utilities
     Witch.Utility.as,
     Witch.Utility.over,
@@ -260,6 +263,7 @@ module Witch
   )
 where
 
+import qualified Witch.Encoding
 import qualified Witch.From
 import Witch.Instances ()
 import qualified Witch.Lift

--- a/source/library/Witch/Encoding.hs
+++ b/source/library/Witch/Encoding.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE DataKinds #-}
+
+module Witch.Encoding where
+
+import qualified Data.Tagged as Tagged
+
+type Utf8 = Tagged.Tagged "UTF-8"

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1038,7 +1038,7 @@ instance From.From ByteString.ByteString LazyByteString.ByteString where
 instance From.From ByteString.ByteString ShortByteString.ShortByteString where
   from = ShortByteString.toShort
 
--- | Uses 'Test.decodeUtf8''.
+-- | Uses 'Text.decodeUtf8''.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text where
   tryFrom = Utility.eitherTryFrom $ Text.decodeUtf8' . Tagged.unTagged
 
@@ -1154,7 +1154,7 @@ instance From.From LazyText.Text String where
 instance From.From String (Tagged.Tagged "UTF-8" ByteString.ByteString) where
   from = Utility.via @Text.Text
 
--- | Converts via 'Text.Text'.
+-- | Converts via 'LazyText.Text'.
 instance From.From String (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
   from = Utility.via @LazyText.Text
 

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1047,14 +1047,14 @@ instance TryFrom.TryFrom ByteString.ByteString (Tagged.Tagged "UTF-8" Text.Text)
 instance TryFrom.TryFrom ByteString.ByteString (Tagged.Tagged "UTF-8" LazyText.Text) where
   tryFrom =
     Utility.eitherTryFrom $
-      fmap From.from
+      fmap (fmap From.from)
         . Utility.tryInto @(Tagged.Tagged "UTF-8" Text.Text)
 
 -- | Converts via 'Text.Text'.
 instance TryFrom.TryFrom ByteString.ByteString (Tagged.Tagged "UTF-8" String) where
   tryFrom =
     Utility.eitherTryFrom $
-      fmap From.from
+      fmap (fmap From.from)
         . Utility.tryInto @(Tagged.Tagged "UTF-8" Text.Text)
 
 -- LazyByteString
@@ -1079,14 +1079,14 @@ instance TryFrom.TryFrom LazyByteString.ByteString (Tagged.Tagged "UTF-8" LazyTe
 instance TryFrom.TryFrom LazyByteString.ByteString (Tagged.Tagged "UTF-8" Text.Text) where
   tryFrom =
     Utility.eitherTryFrom $
-      fmap From.from
+      fmap (fmap From.from)
         . Utility.tryInto @(Tagged.Tagged "UTF-8" LazyText.Text)
 
 -- | Converts via 'LazyText.Text'.
 instance TryFrom.TryFrom LazyByteString.ByteString (Tagged.Tagged "UTF-8" String) where
   tryFrom =
     Utility.eitherTryFrom $
-      fmap From.from
+      fmap (fmap From.from)
         . Utility.tryInto @(Tagged.Tagged "UTF-8" LazyText.Text)
 
 -- ShortByteString
@@ -1153,11 +1153,11 @@ instance From.From LazyText.Text String where
 
 -- | Converts via 'Text.Text'.
 instance From.From (Tagged.Tagged "UTF-8" String) ByteString.ByteString where
-  from = Utility.via @(Tagged.Tagged "UTF-8" Text.Text)
+  from = From.from . fmap (Utility.into @Text.Text)
 
 -- | Converts via 'LazyText.Text'.
 instance From.From (Tagged.Tagged "UTF-8" String) LazyByteString.ByteString where
-  from = Utility.via @(Tagged.Tagged "UTF-8" LazyText.Text)
+  from = From.from . fmap (Utility.into @LazyText.Text)
 
 -- TryFromException
 
@@ -1285,10 +1285,6 @@ instance From.From (Tagged.Tagged s a) a
 
 -- | Uses @coerce@.
 instance From.From (Tagged.Tagged s a) (Tagged.Tagged t a)
-
--- | Uses 'From.from' on the tagged value.
-instance From.From a b => From.From (Tagged.Tagged s a) (Tagged.Tagged s b) where
-  from = fmap From.from
 
 --
 

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -38,6 +38,7 @@ import qualified Data.Word as Word
 import qualified GHC.Float as Float
 import qualified Numeric
 import qualified Numeric.Natural as Natural
+import qualified Witch.Encoding as Encoding
 import qualified Witch.From as From
 import qualified Witch.TryFrom as TryFrom
 import qualified Witch.TryFromException as TryFromException
@@ -1040,22 +1041,22 @@ instance From.From ByteString.ByteString ShortByteString.ShortByteString where
   from = ShortByteString.toShort
 
 -- | Uses 'Text.decodeUtf8''.
-instance TryFrom.TryFrom ByteString.ByteString (Tagged.Tagged "UTF-8" Text.Text) where
+instance TryFrom.TryFrom ByteString.ByteString (Encoding.Utf8 Text.Text) where
   tryFrom = Utility.eitherTryFrom $ fmap Tagged.Tagged . Text.decodeUtf8'
 
 -- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString (Tagged.Tagged "UTF-8" LazyText.Text) where
+instance TryFrom.TryFrom ByteString.ByteString (Encoding.Utf8 LazyText.Text) where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (fmap From.from)
-        . Utility.tryInto @(Tagged.Tagged "UTF-8" Text.Text)
+        . Utility.tryInto @(Encoding.Utf8 Text.Text)
 
 -- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString (Tagged.Tagged "UTF-8" String) where
+instance TryFrom.TryFrom ByteString.ByteString (Encoding.Utf8 String) where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (fmap From.from)
-        . Utility.tryInto @(Tagged.Tagged "UTF-8" Text.Text)
+        . Utility.tryInto @(Encoding.Utf8 Text.Text)
 
 -- LazyByteString
 
@@ -1072,22 +1073,22 @@ instance From.From LazyByteString.ByteString ByteString.ByteString where
   from = LazyByteString.toStrict
 
 -- | Uses 'LazyText.decodeUtf8''.
-instance TryFrom.TryFrom LazyByteString.ByteString (Tagged.Tagged "UTF-8" LazyText.Text) where
+instance TryFrom.TryFrom LazyByteString.ByteString (Encoding.Utf8 LazyText.Text) where
   tryFrom = Utility.eitherTryFrom $ fmap Tagged.Tagged . LazyText.decodeUtf8'
 
 -- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString (Tagged.Tagged "UTF-8" Text.Text) where
+instance TryFrom.TryFrom LazyByteString.ByteString (Encoding.Utf8 Text.Text) where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (fmap From.from)
-        . Utility.tryInto @(Tagged.Tagged "UTF-8" LazyText.Text)
+        . Utility.tryInto @(Encoding.Utf8 LazyText.Text)
 
 -- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString (Tagged.Tagged "UTF-8" String) where
+instance TryFrom.TryFrom LazyByteString.ByteString (Encoding.Utf8 String) where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (fmap From.from)
-        . Utility.tryInto @(Tagged.Tagged "UTF-8" LazyText.Text)
+        . Utility.tryInto @(Encoding.Utf8 LazyText.Text)
 
 -- ShortByteString
 
@@ -1110,11 +1111,11 @@ instance From.From Text.Text LazyText.Text where
   from = LazyText.fromStrict
 
 -- | Uses 'Text.encodeUtf8'.
-instance From.From (Tagged.Tagged "UTF-8" Text.Text) ByteString.ByteString where
+instance From.From (Encoding.Utf8 Text.Text) ByteString.ByteString where
   from = Text.encodeUtf8 . Tagged.unTagged
 
 -- | Converts via 'ByteString.ByteString'.
-instance From.From (Tagged.Tagged "UTF-8" Text.Text) LazyByteString.ByteString where
+instance From.From (Encoding.Utf8 Text.Text) LazyByteString.ByteString where
   from = Utility.via @ByteString.ByteString
 
 -- LazyText
@@ -1124,11 +1125,11 @@ instance From.From LazyText.Text Text.Text where
   from = LazyText.toStrict
 
 -- | Uses 'LazyText.encodeUtf8'.
-instance From.From (Tagged.Tagged "UTF-8" LazyText.Text) LazyByteString.ByteString where
+instance From.From (Encoding.Utf8 LazyText.Text) LazyByteString.ByteString where
   from = LazyText.encodeUtf8 . Tagged.unTagged
 
 -- | Converts via 'LazyByteString.ByteString'.
-instance From.From (Tagged.Tagged "UTF-8" LazyText.Text) ByteString.ByteString where
+instance From.From (Encoding.Utf8 LazyText.Text) ByteString.ByteString where
   from = Utility.via @LazyByteString.ByteString
 
 -- String
@@ -1152,11 +1153,11 @@ instance From.From LazyText.Text String where
   from = LazyText.unpack
 
 -- | Converts via 'Text.Text'.
-instance From.From (Tagged.Tagged "UTF-8" String) ByteString.ByteString where
+instance From.From (Encoding.Utf8 String) ByteString.ByteString where
   from = From.from . fmap (Utility.into @Text.Text)
 
 -- | Converts via 'LazyText.Text'.
-instance From.From (Tagged.Tagged "UTF-8" String) LazyByteString.ByteString where
+instance From.From (Encoding.Utf8 String) LazyByteString.ByteString where
   from = From.from . fmap (Utility.into @LazyText.Text)
 
 -- TryFromException

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -24,9 +24,7 @@ import qualified Data.Ratio as Ratio
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as LazyText
-import qualified Data.Text.Lazy.Encoding as LazyText
 import qualified Data.Time as Time
 import qualified Data.Time.Clock.POSIX as Time
 import qualified Data.Time.Clock.System as Time
@@ -1036,24 +1034,6 @@ instance From.From ByteString.ByteString LazyByteString.ByteString where
 instance From.From ByteString.ByteString ShortByteString.ShortByteString where
   from = ShortByteString.toShort
 
--- | Uses 'Text.decodeUtf8''.
-instance TryFrom.TryFrom ByteString.ByteString Text.Text where
-  tryFrom = Utility.eitherTryFrom Text.decodeUtf8'
-
--- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString LazyText.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @LazyText.Text)
-        . Utility.tryInto @Text.Text
-
--- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
-        . Utility.tryInto @Text.Text
-
 -- LazyByteString
 
 -- | Uses 'LazyByteString.pack'.
@@ -1067,24 +1047,6 @@ instance From.From LazyByteString.ByteString [Word.Word8] where
 -- | Uses 'LazyByteString.toStrict'.
 instance From.From LazyByteString.ByteString ByteString.ByteString where
   from = LazyByteString.toStrict
-
--- | Uses 'LazyText.decodeUtf8''.
-instance TryFrom.TryFrom LazyByteString.ByteString LazyText.Text where
-  tryFrom = Utility.eitherTryFrom LazyText.decodeUtf8'
-
--- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString Text.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @Text.Text)
-        . Utility.tryInto @LazyText.Text
-
--- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
-        . Utility.tryInto @LazyText.Text
 
 -- ShortByteString
 
@@ -1106,27 +1068,11 @@ instance From.From ShortByteString.ShortByteString ByteString.ByteString where
 instance From.From Text.Text LazyText.Text where
   from = LazyText.fromStrict
 
--- | Uses 'Text.encodeUtf8'.
-instance From.From Text.Text ByteString.ByteString where
-  from = Text.encodeUtf8
-
--- | Converts via 'ByteString.ByteString'.
-instance From.From Text.Text LazyByteString.ByteString where
-  from = Utility.via @ByteString.ByteString
-
 -- LazyText
 
 -- | Uses 'LazyText.toStrict'.
 instance From.From LazyText.Text Text.Text where
   from = LazyText.toStrict
-
--- | Uses 'LazyText.encodeUtf8'.
-instance From.From LazyText.Text LazyByteString.ByteString where
-  from = LazyText.encodeUtf8
-
--- | Converts via 'LazyByteString.ByteString'.
-instance From.From LazyText.Text ByteString.ByteString where
-  from = Utility.via @LazyByteString.ByteString
 
 -- String
 
@@ -1147,14 +1093,6 @@ instance From.From String LazyText.Text where
 -- | Uses 'LazyText.unpack'.
 instance From.From LazyText.Text String where
   from = LazyText.unpack
-
--- | Converts via 'Text.Text'.
-instance From.From String ByteString.ByteString where
-  from = Utility.via @Text.Text
-
--- | Converts via 'LazyText.Text'.
-instance From.From String LazyByteString.ByteString where
-  from = Utility.via @LazyText.Text
 
 -- TryFromException
 

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1800,22 +1800,22 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x00]) `shouldBe` ShortByteString.pack [0x00]
         f (ByteString.pack [0x0f, 0xf0]) `shouldBe` ShortByteString.pack [0x0f, 0xf0]
 
-    describe "TryFrom ByteString (Tagged.Tagged \"UTF-8\" Text)" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @(Tagged.Tagged "UTF-8" Text.Text)
+    describe "TryFrom ByteString (Utf8 Text)" $ do
+      let f = hush . Witch.tryFrom @ByteString.ByteString @(Witch.Utf8 Text.Text)
       it "works" $ do
         f (ByteString.pack []) `shouldBe` Just (Tagged.Tagged $ Text.pack "")
         f (ByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ Text.pack "a")
         f (ByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom ByteString (Tagged.Tagged \"UTF-8\" LazyText)" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @(Tagged.Tagged "UTF-8" LazyText.Text)
+    describe "TryFrom ByteString (Utf8 LazyText)" $ do
+      let f = hush . Witch.tryFrom @ByteString.ByteString @(Witch.Utf8 LazyText.Text)
       it "works" $ do
         f (ByteString.pack []) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "")
         f (ByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "a")
         f (ByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom ByteString (Tagged.Tagged \"UTF-8\" String)" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @(Tagged.Tagged "UTF-8" String)
+    describe "TryFrom ByteString (Utf8 String)" $ do
+      let f = hush . Witch.tryFrom @ByteString.ByteString @(Witch.Utf8 String)
       it "works" $ do
         f (ByteString.pack []) `shouldBe` Just (Tagged.Tagged "")
         f (ByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged "a")
@@ -1842,22 +1842,22 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack [0x00]) `shouldBe` ByteString.pack [0x00]
         f (LazyByteString.pack [0x0f, 0xf0]) `shouldBe` ByteString.pack [0x0f, 0xf0]
 
-    describe "TryFrom LazyByteString (Tagged.Tagged \"UTF-8\" LazyText)" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Tagged.Tagged "UTF-8" LazyText.Text)
+    describe "TryFrom LazyByteString (Utf8 LazyText)" $ do
+      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Witch.Utf8 LazyText.Text)
       it "works" $ do
         f (LazyByteString.pack []) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "")
         f (LazyByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "a")
         f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom LazyByteString (Tagged.Tagged \"UTF-8\" Text)" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Tagged.Tagged "UTF-8" Text.Text)
+    describe "TryFrom LazyByteString (Utf8 Text)" $ do
+      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Witch.Utf8 Text.Text)
       it "works" $ do
         f (LazyByteString.pack []) `shouldBe` Just (Tagged.Tagged $ Text.pack "")
         f (LazyByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ Text.pack "a")
         f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom LazyByteString (Tagged.Tagged \"UTF-8\" String)" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Tagged.Tagged "UTF-8" String)
+    describe "TryFrom LazyByteString (Utf8 String)" $ do
+      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Witch.Utf8 String)
       it "works" $ do
         f (LazyByteString.pack []) `shouldBe` Just (Tagged.Tagged "")
         f (LazyByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged "a")
@@ -1891,14 +1891,14 @@ spec = describe "Witch" $ do
         f (Text.pack "a") `shouldBe` LazyText.pack "a"
         f (Text.pack "ab") `shouldBe` LazyText.pack "ab"
 
-    describe "From (Tagged.Tagged \"UTF-8\" Text) ByteString" $ do
-      let f = Witch.from @(Tagged.Tagged "UTF-8" Text.Text) @ByteString.ByteString
+    describe "From (Utf8 Text) ByteString" $ do
+      let f = Witch.from @(Witch.Utf8 Text.Text) @ByteString.ByteString
       it "works" $ do
         f (Tagged.Tagged $ Text.pack "") `shouldBe` ByteString.pack []
         f (Tagged.Tagged $ Text.pack "a") `shouldBe` ByteString.pack [0x61]
 
-    describe "From (Tagged.Tagged \"UTF-8\" Text) LazyByteString" $ do
-      let f = Witch.from @(Tagged.Tagged "UTF-8" Text.Text) @LazyByteString.ByteString
+    describe "From (Utf8 Text) LazyByteString" $ do
+      let f = Witch.from @(Witch.Utf8 Text.Text) @LazyByteString.ByteString
       it "works" $ do
         f (Tagged.Tagged $ Text.pack "") `shouldBe` LazyByteString.pack []
         f (Tagged.Tagged $ Text.pack "a") `shouldBe` LazyByteString.pack [0x61]
@@ -1910,14 +1910,14 @@ spec = describe "Witch" $ do
         f (LazyText.pack "a") `shouldBe` Text.pack "a"
         f (LazyText.pack "ab") `shouldBe` Text.pack "ab"
 
-    describe "From (Tagged.Tagged \"UTF-8\" LazyText) LazyByteString" $ do
-      let f = Witch.from @(Tagged.Tagged "UTF-8" LazyText.Text) @LazyByteString.ByteString
+    describe "From (Utf8 LazyText) LazyByteString" $ do
+      let f = Witch.from @(Witch.Utf8 LazyText.Text) @LazyByteString.ByteString
       it "works" $ do
         f (Tagged.Tagged $ LazyText.pack "") `shouldBe` LazyByteString.pack []
         f (Tagged.Tagged $ LazyText.pack "a") `shouldBe` LazyByteString.pack [0x61]
 
-    describe "From (Tagged.Tagged \"UTF-8\" LazyText) ByteString" $ do
-      let f = Witch.from @(Tagged.Tagged "UTF-8" LazyText.Text) @ByteString.ByteString
+    describe "From (Utf8 LazyText) ByteString" $ do
+      let f = Witch.from @(Witch.Utf8 LazyText.Text) @ByteString.ByteString
       it "works" $ do
         f (Tagged.Tagged $ LazyText.pack "") `shouldBe` ByteString.pack []
         f (Tagged.Tagged $ LazyText.pack "a") `shouldBe` ByteString.pack [0x61]
@@ -1950,14 +1950,14 @@ spec = describe "Witch" $ do
         f (LazyText.pack "a") `shouldBe` "a"
         f (LazyText.pack "ab") `shouldBe` "ab"
 
-    describe "From (Tagged.Tagged \"UTF-8\" String) ByteString" $ do
-      let f = Witch.from @(Tagged.Tagged "UTF-8" String) @ByteString.ByteString
+    describe "From (Utf8 String) ByteString" $ do
+      let f = Witch.from @(Witch.Utf8 String) @ByteString.ByteString
       it "works" $ do
         f (Tagged.Tagged "") `shouldBe` ByteString.pack []
         f (Tagged.Tagged "a") `shouldBe` ByteString.pack [0x61]
 
-    describe "From (Tagged.Tagged \"UTF-8\" String) LazyByteString" $ do
-      let f = Witch.from @(Tagged.Tagged "UTF-8" String) @LazyByteString.ByteString
+    describe "From (Utf8 String) LazyByteString" $ do
+      let f = Witch.from @(Witch.Utf8 String) @LazyByteString.ByteString
       it "works" $ do
         f (Tagged.Tagged "") `shouldBe` LazyByteString.pack []
         f (Tagged.Tagged "a") `shouldBe` LazyByteString.pack [0x61]

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -2087,11 +2087,6 @@ spec = describe "Witch" $ do
       it "works" $ do
         f 1 `shouldBe` 1
 
-    describe "From (Tagged s a) (Tagged s b)" $ do
-      let f = Witch.from @(Tagged.Tagged () Int.Int8) @(Tagged.Tagged () Int.Int16)
-      it "works" $ do
-        f 1 `shouldBe` 1
-
 newtype Age
   = Age Int.Int8
   deriving (Eq, Show)

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -20,6 +21,7 @@ import qualified Data.Map as Map
 import qualified Data.Ratio as Ratio
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
+import qualified Data.Tagged as Tagged
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Time as Time
@@ -1798,6 +1800,27 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x00]) `shouldBe` ShortByteString.pack [0x00]
         f (ByteString.pack [0x0f, 0xf0]) `shouldBe` ShortByteString.pack [0x0f, 0xf0]
 
+    describe "TryFrom (Tagged.Tagged \"UTF-8\" ByteString) Text" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
+      it "works" $ do
+        f (Tagged.Tagged $ ByteString.pack []) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged $ ByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged $ ByteString.pack [0xff]) `shouldBe` Nothing
+
+    describe "TryFrom (Tagged.Tagged \"UTF-8\" ByteString) LazyText" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
+      it "works" $ do
+        f (Tagged.Tagged $ ByteString.pack []) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged $ ByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged $ ByteString.pack [0xff]) `shouldBe` Nothing
+
+    describe "TryFrom (Tagged.Tagged \"UTF-8\" ByteString) String" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
+      it "works" $ do
+        f (Tagged.Tagged $ ByteString.pack []) `shouldBe` Just ""
+        f (Tagged.Tagged $ ByteString.pack [0x61]) `shouldBe` Just "a"
+        f (Tagged.Tagged $ ByteString.pack [0xff]) `shouldBe` Nothing
+
     describe "From [Word8] LazyByteString" $ do
       let f = Witch.from @[Word.Word8] @LazyByteString.ByteString
       it "works" $ do
@@ -1818,6 +1841,27 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack []) `shouldBe` ByteString.pack []
         f (LazyByteString.pack [0x00]) `shouldBe` ByteString.pack [0x00]
         f (LazyByteString.pack [0x0f, 0xf0]) `shouldBe` ByteString.pack [0x0f, 0xf0]
+
+    describe "TryFrom (Tagged.Tagged \"UTF-8\" LazyByteString) LazyText" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
+      it "works" $ do
+        f (Tagged.Tagged $ LazyByteString.pack []) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged $ LazyByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged $ LazyByteString.pack [0xff]) `shouldBe` Nothing
+
+    describe "TryFrom (Tagged.Tagged \"UTF-8\" LazyByteString) Text" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @Text.Text
+      it "works" $ do
+        f (Tagged.Tagged $ LazyByteString.pack []) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged $ LazyByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged $ LazyByteString.pack [0xff]) `shouldBe` Nothing
+
+    describe "TryFrom (Tagged.Tagged \"UTF-8\" LazyByteString) String" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
+      it "works" $ do
+        f (Tagged.Tagged $ LazyByteString.pack []) `shouldBe` Just ""
+        f (Tagged.Tagged $ LazyByteString.pack [0x61]) `shouldBe` Just "a"
+        f (Tagged.Tagged $ LazyByteString.pack [0xff]) `shouldBe` Nothing
 
     describe "From [Word8] ShortByteString" $ do
       let f = Witch.from @[Word.Word8] @ShortByteString.ShortByteString
@@ -1847,12 +1891,36 @@ spec = describe "Witch" $ do
         f (Text.pack "a") `shouldBe` LazyText.pack "a"
         f (Text.pack "ab") `shouldBe` LazyText.pack "ab"
 
+    describe "From Text (Tagged \"UTF-8\" ByteString)" $ do
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+
+    describe "From Text (Tagged \"UTF-8\" LazyByteString)" $ do
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+
     describe "From LazyText Text" $ do
       let f = Witch.from @LazyText.Text @Text.Text
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Text.pack ""
         f (LazyText.pack "a") `shouldBe` Text.pack "a"
         f (LazyText.pack "ab") `shouldBe` Text.pack "ab"
+
+    describe "From LazyText (Tagged \"UTF-8\" LazyByteString)" $ do
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+
+    describe "From LazyText (Tagged \"UTF-8\" ByteString)" $ do
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From String Text" $ do
       let f = Witch.from @String @Text.Text
@@ -1881,6 +1949,18 @@ spec = describe "Witch" $ do
         f (LazyText.pack "") `shouldBe` ""
         f (LazyText.pack "a") `shouldBe` "a"
         f (LazyText.pack "ab") `shouldBe` "ab"
+
+    describe "From String (Tagged \"UTF-8\" ByteString)" $ do
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+
+    describe "From String (Tagged \"UTF-8\" LazyByteString)" $ do
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From Integer Day" $ do
       let f = Witch.from @Integer @Time.Day
@@ -1991,6 +2071,16 @@ spec = describe "Witch" $ do
       let f = Witch.from @Time.ZonedTime @Time.UTCTime
       it "works" $ do
         f (Time.ZonedTime (Time.LocalTime (Time.ModifiedJulianDay 0) (Time.TimeOfDay 0 0 0)) Time.utc) `shouldBe` Time.UTCTime (Time.ModifiedJulianDay 0) 0
+
+    describe "From b (Tagged s b)" $ do
+      let f = Witch.from @Int @(Tagged.Tagged () Int)
+      it "works" $ do
+        f 1 `shouldBe` 1
+
+    describe "From (Tagged s b) b" $ do
+      let f = Witch.from @(Tagged.Tagged () Int) @Int
+      it "works" $ do
+        f 1 `shouldBe` 1
 
 newtype Age
   = Age Int.Int8

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1798,27 +1798,6 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x00]) `shouldBe` ShortByteString.pack [0x00]
         f (ByteString.pack [0x0f, 0xf0]) `shouldBe` ShortByteString.pack [0x0f, 0xf0]
 
-    describe "TryFrom ByteString Text" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @Text.Text
-      it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (ByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom ByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @LazyText.Text
-      it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (ByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom ByteString String" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @String
-      it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just ""
-        f (ByteString.pack [0x61]) `shouldBe` Just "a"
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
-
     describe "From [Word8] LazyByteString" $ do
       let f = Witch.from @[Word.Word8] @LazyByteString.ByteString
       it "works" $ do
@@ -1839,27 +1818,6 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack []) `shouldBe` ByteString.pack []
         f (LazyByteString.pack [0x00]) `shouldBe` ByteString.pack [0x00]
         f (LazyByteString.pack [0x0f, 0xf0]) `shouldBe` ByteString.pack [0x0f, 0xf0]
-
-    describe "TryFrom LazyByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @LazyText.Text
-      it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (LazyByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom LazyByteString Text" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @Text.Text
-      it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (LazyByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom LazyByteString String" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @String
-      it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just ""
-        f (LazyByteString.pack [0x61]) `shouldBe` Just "a"
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
     describe "From [Word8] ShortByteString" $ do
       let f = Witch.from @[Word.Word8] @ShortByteString.ShortByteString
@@ -1889,36 +1847,12 @@ spec = describe "Witch" $ do
         f (Text.pack "a") `shouldBe` LazyText.pack "a"
         f (Text.pack "ab") `shouldBe` LazyText.pack "ab"
 
-    describe "From Text ByteString" $ do
-      let f = Witch.from @Text.Text @ByteString.ByteString
-      it "works" $ do
-        f (Text.pack "") `shouldBe` ByteString.pack []
-        f (Text.pack "a") `shouldBe` ByteString.pack [0x61]
-
-    describe "From Text LazyByteString" $ do
-      let f = Witch.from @Text.Text @LazyByteString.ByteString
-      it "works" $ do
-        f (Text.pack "") `shouldBe` LazyByteString.pack []
-        f (Text.pack "a") `shouldBe` LazyByteString.pack [0x61]
-
     describe "From LazyText Text" $ do
       let f = Witch.from @LazyText.Text @Text.Text
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Text.pack ""
         f (LazyText.pack "a") `shouldBe` Text.pack "a"
         f (LazyText.pack "ab") `shouldBe` Text.pack "ab"
-
-    describe "From LazyText LazyByteString" $ do
-      let f = Witch.from @LazyText.Text @LazyByteString.ByteString
-      it "works" $ do
-        f (LazyText.pack "") `shouldBe` LazyByteString.pack []
-        f (LazyText.pack "a") `shouldBe` LazyByteString.pack [0x61]
-
-    describe "From LazyText ByteString" $ do
-      let f = Witch.from @LazyText.Text @ByteString.ByteString
-      it "works" $ do
-        f (LazyText.pack "") `shouldBe` ByteString.pack []
-        f (LazyText.pack "a") `shouldBe` ByteString.pack [0x61]
 
     describe "From String Text" $ do
       let f = Witch.from @String @Text.Text
@@ -1947,18 +1881,6 @@ spec = describe "Witch" $ do
         f (LazyText.pack "") `shouldBe` ""
         f (LazyText.pack "a") `shouldBe` "a"
         f (LazyText.pack "ab") `shouldBe` "ab"
-
-    describe "From String ByteString" $ do
-      let f = Witch.from @String @ByteString.ByteString
-      it "works" $ do
-        f "" `shouldBe` ByteString.pack []
-        f "a" `shouldBe` ByteString.pack [0x61]
-
-    describe "From String LazyByteString" $ do
-      let f = Witch.from @String @LazyByteString.ByteString
-      it "works" $ do
-        f "" `shouldBe` LazyByteString.pack []
-        f "a" `shouldBe` LazyByteString.pack [0x61]
 
     describe "From Integer Day" $ do
       let f = Witch.from @Integer @Time.Day

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1800,26 +1800,26 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x00]) `shouldBe` ShortByteString.pack [0x00]
         f (ByteString.pack [0x0f, 0xf0]) `shouldBe` ShortByteString.pack [0x0f, 0xf0]
 
-    describe "TryFrom (Tagged.Tagged \"UTF-8\" ByteString) Text" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
+    describe "TryFrom ByteString (Tagged.Tagged \"UTF-8\" Text)" $ do
+      let f = hush . Witch.tryFrom @ByteString.ByteString @(Tagged.Tagged "UTF-8" Text.Text)
       it "works" $ do
-        f (Tagged.Tagged $ ByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (Tagged.Tagged $ ByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (Tagged.Tagged $ ByteString.pack [0xff]) `shouldBe` Nothing
+        f (ByteString.pack []) `shouldBe` Just (Tagged.Tagged $ Text.pack "")
+        f (ByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ Text.pack "a")
+        f (ByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom (Tagged.Tagged \"UTF-8\" ByteString) LazyText" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
+    describe "TryFrom ByteString (Tagged.Tagged \"UTF-8\" LazyText)" $ do
+      let f = hush . Witch.tryFrom @ByteString.ByteString @(Tagged.Tagged "UTF-8" LazyText.Text)
       it "works" $ do
-        f (Tagged.Tagged $ ByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (Tagged.Tagged $ ByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (Tagged.Tagged $ ByteString.pack [0xff]) `shouldBe` Nothing
+        f (ByteString.pack []) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "")
+        f (ByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "a")
+        f (ByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom (Tagged.Tagged \"UTF-8\" ByteString) String" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
+    describe "TryFrom ByteString (Tagged.Tagged \"UTF-8\" String)" $ do
+      let f = hush . Witch.tryFrom @ByteString.ByteString @(Tagged.Tagged "UTF-8" String)
       it "works" $ do
-        f (Tagged.Tagged $ ByteString.pack []) `shouldBe` Just ""
-        f (Tagged.Tagged $ ByteString.pack [0x61]) `shouldBe` Just "a"
-        f (Tagged.Tagged $ ByteString.pack [0xff]) `shouldBe` Nothing
+        f (ByteString.pack []) `shouldBe` Just (Tagged.Tagged "")
+        f (ByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged "a")
+        f (ByteString.pack [0xff]) `shouldBe` Nothing
 
     describe "From [Word8] LazyByteString" $ do
       let f = Witch.from @[Word.Word8] @LazyByteString.ByteString
@@ -1842,26 +1842,26 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack [0x00]) `shouldBe` ByteString.pack [0x00]
         f (LazyByteString.pack [0x0f, 0xf0]) `shouldBe` ByteString.pack [0x0f, 0xf0]
 
-    describe "TryFrom (Tagged.Tagged \"UTF-8\" LazyByteString) LazyText" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
+    describe "TryFrom LazyByteString (Tagged.Tagged \"UTF-8\" LazyText)" $ do
+      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Tagged.Tagged "UTF-8" LazyText.Text)
       it "works" $ do
-        f (Tagged.Tagged $ LazyByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (Tagged.Tagged $ LazyByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (Tagged.Tagged $ LazyByteString.pack [0xff]) `shouldBe` Nothing
+        f (LazyByteString.pack []) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "")
+        f (LazyByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ LazyText.pack "a")
+        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom (Tagged.Tagged \"UTF-8\" LazyByteString) Text" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @Text.Text
+    describe "TryFrom LazyByteString (Tagged.Tagged \"UTF-8\" Text)" $ do
+      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Tagged.Tagged "UTF-8" Text.Text)
       it "works" $ do
-        f (Tagged.Tagged $ LazyByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (Tagged.Tagged $ LazyByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (Tagged.Tagged $ LazyByteString.pack [0xff]) `shouldBe` Nothing
+        f (LazyByteString.pack []) `shouldBe` Just (Tagged.Tagged $ Text.pack "")
+        f (LazyByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged $ Text.pack "a")
+        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
-    describe "TryFrom (Tagged.Tagged \"UTF-8\" LazyByteString) String" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
+    describe "TryFrom LazyByteString (Tagged.Tagged \"UTF-8\" String)" $ do
+      let f = hush . Witch.tryFrom @LazyByteString.ByteString @(Tagged.Tagged "UTF-8" String)
       it "works" $ do
-        f (Tagged.Tagged $ LazyByteString.pack []) `shouldBe` Just ""
-        f (Tagged.Tagged $ LazyByteString.pack [0x61]) `shouldBe` Just "a"
-        f (Tagged.Tagged $ LazyByteString.pack [0xff]) `shouldBe` Nothing
+        f (LazyByteString.pack []) `shouldBe` Just (Tagged.Tagged "")
+        f (LazyByteString.pack [0x61]) `shouldBe` Just (Tagged.Tagged "a")
+        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
     describe "From [Word8] ShortByteString" $ do
       let f = Witch.from @[Word.Word8] @ShortByteString.ShortByteString
@@ -1891,17 +1891,17 @@ spec = describe "Witch" $ do
         f (Text.pack "a") `shouldBe` LazyText.pack "a"
         f (Text.pack "ab") `shouldBe` LazyText.pack "ab"
 
-    describe "From Text (Tagged \"UTF-8\" ByteString)" $ do
-      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+    describe "From (Tagged.Tagged \"UTF-8\" Text) ByteString" $ do
+      let f = Witch.from @(Tagged.Tagged "UTF-8" Text.Text) @ByteString.ByteString
       it "works" $ do
-        f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
-        f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+        f (Tagged.Tagged $ Text.pack "") `shouldBe` ByteString.pack []
+        f (Tagged.Tagged $ Text.pack "a") `shouldBe` ByteString.pack [0x61]
 
-    describe "From Text (Tagged \"UTF-8\" LazyByteString)" $ do
-      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+    describe "From (Tagged.Tagged \"UTF-8\" Text) LazyByteString" $ do
+      let f = Witch.from @(Tagged.Tagged "UTF-8" Text.Text) @LazyByteString.ByteString
       it "works" $ do
-        f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
-        f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+        f (Tagged.Tagged $ Text.pack "") `shouldBe` LazyByteString.pack []
+        f (Tagged.Tagged $ Text.pack "a") `shouldBe` LazyByteString.pack [0x61]
 
     describe "From LazyText Text" $ do
       let f = Witch.from @LazyText.Text @Text.Text
@@ -1910,17 +1910,17 @@ spec = describe "Witch" $ do
         f (LazyText.pack "a") `shouldBe` Text.pack "a"
         f (LazyText.pack "ab") `shouldBe` Text.pack "ab"
 
-    describe "From LazyText (Tagged \"UTF-8\" LazyByteString)" $ do
-      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+    describe "From (Tagged.Tagged \"UTF-8\" LazyText) LazyByteString" $ do
+      let f = Witch.from @(Tagged.Tagged "UTF-8" LazyText.Text) @LazyByteString.ByteString
       it "works" $ do
-        f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
-        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+        f (Tagged.Tagged $ LazyText.pack "") `shouldBe` LazyByteString.pack []
+        f (Tagged.Tagged $ LazyText.pack "a") `shouldBe` LazyByteString.pack [0x61]
 
-    describe "From LazyText (Tagged \"UTF-8\" ByteString)" $ do
-      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+    describe "From (Tagged.Tagged \"UTF-8\" LazyText) ByteString" $ do
+      let f = Witch.from @(Tagged.Tagged "UTF-8" LazyText.Text) @ByteString.ByteString
       it "works" $ do
-        f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
-        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+        f (Tagged.Tagged $ LazyText.pack "") `shouldBe` ByteString.pack []
+        f (Tagged.Tagged $ LazyText.pack "a") `shouldBe` ByteString.pack [0x61]
 
     describe "From String Text" $ do
       let f = Witch.from @String @Text.Text
@@ -1950,17 +1950,17 @@ spec = describe "Witch" $ do
         f (LazyText.pack "a") `shouldBe` "a"
         f (LazyText.pack "ab") `shouldBe` "ab"
 
-    describe "From String (Tagged \"UTF-8\" ByteString)" $ do
-      let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+    describe "From (Tagged.Tagged \"UTF-8\" String) ByteString" $ do
+      let f = Witch.from @(Tagged.Tagged "UTF-8" String) @ByteString.ByteString
       it "works" $ do
-        f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
-        f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+        f (Tagged.Tagged "") `shouldBe` ByteString.pack []
+        f (Tagged.Tagged "a") `shouldBe` ByteString.pack [0x61]
 
-    describe "From String (Tagged \"UTF-8\" LazyByteString)" $ do
-      let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+    describe "From (Tagged.Tagged \"UTF-8\" String) LazyByteString" $ do
+      let f = Witch.from @(Tagged.Tagged "UTF-8" String) @LazyByteString.ByteString
       it "works" $ do
-        f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])
-        f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+        f (Tagged.Tagged "") `shouldBe` LazyByteString.pack []
+        f (Tagged.Tagged "a") `shouldBe` LazyByteString.pack [0x61]
 
     describe "From Integer Day" $ do
       let f = Witch.from @Integer @Time.Day
@@ -2072,13 +2072,23 @@ spec = describe "Witch" $ do
       it "works" $ do
         f (Time.ZonedTime (Time.LocalTime (Time.ModifiedJulianDay 0) (Time.TimeOfDay 0 0 0)) Time.utc) `shouldBe` Time.UTCTime (Time.ModifiedJulianDay 0) 0
 
-    describe "From b (Tagged s b)" $ do
+    describe "From a (Tagged s a)" $ do
       let f = Witch.from @Int @(Tagged.Tagged () Int)
       it "works" $ do
         f 1 `shouldBe` 1
 
-    describe "From (Tagged s b) b" $ do
+    describe "From (Tagged s a) a" $ do
       let f = Witch.from @(Tagged.Tagged () Int) @Int
+      it "works" $ do
+        f 1 `shouldBe` 1
+
+    describe "From (Tagged s a) (Tagged t a)" $ do
+      let f = Witch.from @(Tagged.Tagged "old" Int) @(Tagged.Tagged "new" Int)
+      it "works" $ do
+        f 1 `shouldBe` 1
+
+    describe "From (Tagged s a) (Tagged s b)" $ do
+      let f = Witch.from @(Tagged.Tagged () Int.Int8) @(Tagged.Tagged () Int.Int16)
       it "works" $ do
         f 1 `shouldBe` 1
 

--- a/witch.cabal
+++ b/witch.cabal
@@ -76,6 +76,7 @@ library
     , template-haskell >= 2.12 && < 2.20
   exposed-modules:
     Witch
+    Witch.Encoding
     Witch.From
     Witch.Instances
     Witch.Lift

--- a/witch.cabal
+++ b/witch.cabal
@@ -26,6 +26,7 @@ common library
     , base >= 4.10 && < 4.18
     , bytestring >= 0.10.8 && < 0.12
     , containers >= 0.5.10 && < 0.7
+    , tagged >= 0.8.6 && < 0.9
     , text >= 1.2.3 && < 1.3 || >= 2.0 && < 2.1
     , time >= 1.9.1 && < 1.13
   default-language: Haskell2010


### PR DESCRIPTION
This fixes #56. 

This would be a breaking change! 

This PR uses the `Tagged` type to handle conversions between `Text` and `ByteString`. 

:warning: Update: See https://github.com/tfausak/witch/pull/58#issuecomment-1243066616 for the new API.

``` hs
-- before
from @Text @ByteString "..."

-- after
from @Text @(Tagged "UTF-8" ByteString) "..."
```

Here's a more complete example:

``` hs
:set -XDataKinds
:set -XOverloadedStrings
:set -XTypeApplications

import qualified Data.Tagged as Tagged
import qualified Data.ByteString as ByteString
import qualified Witch

type Utf8 = Tagged.Tagged "UTF-8" ByteString.ByteString

Witch.from @String @Utf8 "\x24 \xa3 \x20ac \x10348"
-- Tagged "$ \194\163 \226\130\172 \240\144\141\136"

Witch.tryFrom @Utf8 @String "$ \194\163 \226\130\172 \240\144\141\136"
-- Right "$ \163 \8364 \66376"

Witch.tryFrom @Utf8 @String "\xff"
-- Left (TryFromException @(Tagged Symbol "UTF-8" ByteString) @[Char] (Tagged "\255") (Just (TryFromException @(Tagged Symbol "UTF-8" ByteString) @Text (Tagged "\255") (Just Cannot decode byte '\xff': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream))))
```