### PR TITLE
Tag UTF-8 instances

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,7 +1,7 @@
 services:
   devcontainer:
     command: sh -c 'while sleep 1; do :; done'
-    image: ghcr.io/acilearning/docker-haskell:9.2.4
+    image: public.ecr.aws/v6m6o3k4/haskell:9.2.4-a853e18e0505bc9590dd6eaa31231ae2610fbfa8
     init: true
     volumes:
       - ..:/workspaces/witch

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -1280,6 +1281,9 @@ instance From.From a (Tagged.Tagged t a)
 
 -- | Uses @coerce@. Essentially the same as 'Tagged.unTagged'.
 instance From.From (Tagged.Tagged t a) a
+
+-- | Uses @coerce@. Essentially the same as 'Tagged.retag'.
+instance From.From (Tagged.Tagged t a) (Tagged.Tagged u a)
 
 --
 

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -23,6 +23,7 @@ import qualified Data.Map as Map
 import qualified Data.Ratio as Ratio
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
+import qualified Data.Tagged as Tagged
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as LazyText
@@ -1271,6 +1272,11 @@ instance From.From Time.NominalDiffTime Time.CalendarDiffTime where
 -- | Uses 'Time.zonedTimeToUTC'.
 instance From.From Time.ZonedTime Time.UTCTime where
   from = Time.zonedTimeToUTC
+
+-- Tagged
+
+-- | Uses @coerce@. Essentially the same as 'Tagged.Tagged'.
+instance From.From a (Tagged.Tagged t a)
 
 --
 

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
@@ -1039,18 +1040,18 @@ instance From.From ByteString.ByteString ShortByteString.ShortByteString where
   from = ShortByteString.toShort
 
 -- | Uses 'Text.decodeUtf8''.
-instance TryFrom.TryFrom ByteString.ByteString Text.Text where
-  tryFrom = Utility.eitherTryFrom Text.decodeUtf8'
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text where
+  tryFrom = Utility.eitherTryFrom $ Text.decodeUtf8' . From.from
 
 -- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString LazyText.Text where
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) LazyText.Text where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @LazyText.Text)
         . Utility.tryInto @Text.Text
 
 -- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString String where
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) String where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @String)
@@ -1071,18 +1072,18 @@ instance From.From LazyByteString.ByteString ByteString.ByteString where
   from = LazyByteString.toStrict
 
 -- | Uses 'LazyText.decodeUtf8''.
-instance TryFrom.TryFrom LazyByteString.ByteString LazyText.Text where
-  tryFrom = Utility.eitherTryFrom LazyText.decodeUtf8'
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyText.Text where
+  tryFrom = Utility.eitherTryFrom $ LazyText.decodeUtf8' . From.from
 
 -- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString Text.Text where
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) Text.Text where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @Text.Text)
         . Utility.tryInto @LazyText.Text
 
 -- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString String where
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) String where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @String)
@@ -1109,12 +1110,12 @@ instance From.From Text.Text LazyText.Text where
   from = LazyText.fromStrict
 
 -- | Uses 'Text.encodeUtf8'.
-instance From.From Text.Text ByteString.ByteString where
-  from = Text.encodeUtf8
+instance From.From Text.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = From.from . Text.encodeUtf8
 
 -- | Converts via 'ByteString.ByteString'.
-instance From.From Text.Text LazyByteString.ByteString where
-  from = Utility.via @ByteString.ByteString
+instance From.From Text.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" ByteString.ByteString)
 
 -- LazyText
 
@@ -1123,12 +1124,12 @@ instance From.From LazyText.Text Text.Text where
   from = LazyText.toStrict
 
 -- | Uses 'LazyText.encodeUtf8'.
-instance From.From LazyText.Text LazyByteString.ByteString where
-  from = LazyText.encodeUtf8
+instance From.From LazyText.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+  from = From.from . LazyText.encodeUtf8
 
 -- | Converts via 'LazyByteString.ByteString'.
-instance From.From LazyText.Text ByteString.ByteString where
-  from = Utility.via @LazyByteString.ByteString
+instance From.From LazyText.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
 
 -- String
 
@@ -1151,11 +1152,11 @@ instance From.From LazyText.Text String where
   from = LazyText.unpack
 
 -- | Converts via 'Text.Text'.
-instance From.From String ByteString.ByteString where
+instance From.From String (Tagged.Tagged "UTF-8" ByteString.ByteString) where
   from = Utility.via @Text.Text
 
 -- | Converts via 'LazyText.Text'.
-instance From.From String LazyByteString.ByteString where
+instance From.From String (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
   from = Utility.via @LazyText.Text
 
 -- TryFromException

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1278,6 +1278,9 @@ instance From.From Time.ZonedTime Time.UTCTime where
 -- | Uses @coerce@. Essentially the same as 'Tagged.Tagged'.
 instance From.From a (Tagged.Tagged t a)
 
+-- | Uses @coerce@. Essentially the same as 'Tagged.unTagged'.
+instance From.From (Tagged.Tagged t a) a
+
 --
 
 realFloatToRational ::

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1801,25 +1801,25 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x0f, 0xf0]) `shouldBe` ShortByteString.pack [0x0f, 0xf0]
 
     describe "TryFrom ByteString Text" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @Text.Text
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
       it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (ByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom ByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @LazyText.Text
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
       it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (ByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom ByteString String" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @String
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
       it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just ""
-        f (ByteString.pack [0x61]) `shouldBe` Just "a"
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just ""
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just "a"
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "From [Word8] LazyByteString" $ do
       let f = Witch.from @[Word.Word8] @LazyByteString.ByteString
@@ -1843,25 +1843,25 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack [0x0f, 0xf0]) `shouldBe` ByteString.pack [0x0f, 0xf0]
 
     describe "TryFrom LazyByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @LazyText.Text
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
       it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (LazyByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom LazyByteString Text" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @Text.Text
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @Text.Text
       it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (LazyByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom LazyByteString String" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @String
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
       it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just ""
-        f (LazyByteString.pack [0x61]) `shouldBe` Just "a"
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just ""
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just "a"
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "From [Word8] ShortByteString" $ do
       let f = Witch.from @[Word.Word8] @ShortByteString.ShortByteString
@@ -1892,16 +1892,16 @@ spec = describe "Witch" $ do
         f (Text.pack "ab") `shouldBe` LazyText.pack "ab"
 
     describe "From Text ByteString" $ do
-      let f = Witch.from @Text.Text @ByteString.ByteString
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
       it "works" $ do
-        f (Text.pack "") `shouldBe` ByteString.pack []
-        f (Text.pack "a") `shouldBe` ByteString.pack [0x61]
+        f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From Text LazyByteString" $ do
-      let f = Witch.from @Text.Text @LazyByteString.ByteString
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
       it "works" $ do
-        f (Text.pack "") `shouldBe` LazyByteString.pack []
-        f (Text.pack "a") `shouldBe` LazyByteString.pack [0x61]
+        f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From LazyText Text" $ do
       let f = Witch.from @LazyText.Text @Text.Text
@@ -1911,16 +1911,16 @@ spec = describe "Witch" $ do
         f (LazyText.pack "ab") `shouldBe` Text.pack "ab"
 
     describe "From LazyText LazyByteString" $ do
-      let f = Witch.from @LazyText.Text @LazyByteString.ByteString
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
       it "works" $ do
-        f (LazyText.pack "") `shouldBe` LazyByteString.pack []
-        f (LazyText.pack "a") `shouldBe` LazyByteString.pack [0x61]
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From LazyText ByteString" $ do
-      let f = Witch.from @LazyText.Text @ByteString.ByteString
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
       it "works" $ do
-        f (LazyText.pack "") `shouldBe` ByteString.pack []
-        f (LazyText.pack "a") `shouldBe` ByteString.pack [0x61]
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From String Text" $ do
       let f = Witch.from @String @Text.Text
@@ -1951,16 +1951,16 @@ spec = describe "Witch" $ do
         f (LazyText.pack "ab") `shouldBe` "ab"
 
     describe "From String ByteString" $ do
-      let f = Witch.from @String @ByteString.ByteString
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
       it "works" $ do
-        f "" `shouldBe` ByteString.pack []
-        f "a" `shouldBe` ByteString.pack [0x61]
+        f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From String LazyByteString" $ do
-      let f = Witch.from @String @LazyByteString.ByteString
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
       it "works" $ do
-        f "" `shouldBe` LazyByteString.pack []
-        f "a" `shouldBe` LazyByteString.pack [0x61]
+        f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From Integer Day" $ do
       let f = Witch.from @Integer @Time.Day

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -20,6 +20,7 @@ import qualified Data.Map as Map
 import qualified Data.Ratio as Ratio
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
+import qualified Data.Tagged as Tagged
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Time as Time
@@ -2069,6 +2070,11 @@ spec = describe "Witch" $ do
       let f = Witch.from @Time.ZonedTime @Time.UTCTime
       it "works" $ do
         f (Time.ZonedTime (Time.LocalTime (Time.ModifiedJulianDay 0) (Time.TimeOfDay 0 0 0)) Time.utc) `shouldBe` Time.UTCTime (Time.ModifiedJulianDay 0) 0
+
+    describe "From a (Tagged t a)" $ do
+      let f = Witch.from @Bool @(Tagged.Tagged () Bool)
+      it "works" $ do
+        f False `shouldBe` Tagged.Tagged False
 
 newtype Age
   = Age Int.Int8

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -2076,6 +2076,11 @@ spec = describe "Witch" $ do
       it "works" $ do
         f False `shouldBe` Tagged.Tagged False
 
+    describe "From (Tagged t a) a" $ do
+      let f = Witch.from @(Tagged.Tagged () Bool) @Bool
+      it "works" $ do
+        f (Tagged.Tagged False) `shouldBe` False
+
 newtype Age
   = Age Int.Int8
   deriving (Eq, Show)

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -2080,6 +2081,11 @@ spec = describe "Witch" $ do
       let f = Witch.from @(Tagged.Tagged () Bool) @Bool
       it "works" $ do
         f (Tagged.Tagged False) `shouldBe` False
+
+    describe "From (Tagged t a) (Tagged u a)" $ do
+      let f = Witch.from @(Tagged.Tagged "old" Bool) @(Tagged.Tagged "new" Bool)
+      it "works" $ do
+        f (Tagged.Tagged False) `shouldBe` Tagged.Tagged False
 
 newtype Age
   = Age Int.Int8

--- a/witch.cabal
+++ b/witch.cabal
@@ -26,6 +26,7 @@ common library
     , base >= 4.10 && < 4.18
     , bytestring >= 0.10.8 && < 0.12
     , containers >= 0.5.10 && < 0.7
+    , tagged >= 0.8.6 && < 0.9
     , text >= 1.2.3 && < 1.3 || >= 2.0 && < 2.1
     , time >= 1.9.1 && < 1.13
   default-language: Haskell2010


### PR DESCRIPTION
Fixes #56. See discussion in #58 and [on Discourse](https://discourse.haskell.org/t/help-with-designing-an-api-for-text-encodings/5110?u=taylorfausak). 

This pull request removes instances for converting between `Text` and `ByteString`. It replaces them with instances that use [the `Tagged` data type](https://hackage.haskell.org/package/tagged-0.8.6.1/docs/Data-Tagged.html#t:Tagged) to select an encoding. It also introduces some new instances for dealing with `Tagged` values. Here's a quick example to show how code needs to be updated in response to this change:

``` hs
-- before
from @Text @ByteString "\955"
-- "\206\187"

-- after
from @Text @(Tagged "UTF-8" ByteString) "\955"
-- Tagged "\206\187"
```

``` hs
-- before
tryFrom @ByteString @Text "\206\187"
-- Right "\955"

-- after
tryFrom @(Tagged "UTF-8" ByteString) @Text (Tagged "\206\187")
-- Right "\955"
```

I'm showing example with `ByteString` and `Text`, but this also applies to `LazyByteString`, `LazyText`, and `String`. 