### PR TITLE
Add instances for `Tagged` values

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,7 +1,7 @@
 services:
   devcontainer:
     command: sh -c 'while sleep 1; do :; done'
-    image: ghcr.io/acilearning/docker-haskell:9.2.4
+    image: public.ecr.aws/v6m6o3k4/haskell:9.2.4-a853e18e0505bc9590dd6eaa31231ae2610fbfa8
     init: true
     volumes:
       - ..:/workspaces/witch

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -1280,6 +1281,9 @@ instance From.From a (Tagged.Tagged t a)
 
 -- | Uses @coerce@. Essentially the same as 'Tagged.unTagged'.
 instance From.From (Tagged.Tagged t a) a
+
+-- | Uses @coerce@. Essentially the same as 'Tagged.retag'.
+instance From.From (Tagged.Tagged t a) (Tagged.Tagged u a)
 
 --
 

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -23,6 +23,7 @@ import qualified Data.Map as Map
 import qualified Data.Ratio as Ratio
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
+import qualified Data.Tagged as Tagged
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as LazyText
@@ -1271,6 +1272,11 @@ instance From.From Time.NominalDiffTime Time.CalendarDiffTime where
 -- | Uses 'Time.zonedTimeToUTC'.
 instance From.From Time.ZonedTime Time.UTCTime where
   from = Time.zonedTimeToUTC
+
+-- Tagged
+
+-- | Uses @coerce@. Essentially the same as 'Tagged.Tagged'.
+instance From.From a (Tagged.Tagged t a)
 
 --
 

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1278,6 +1278,9 @@ instance From.From Time.ZonedTime Time.UTCTime where
 -- | Uses @coerce@. Essentially the same as 'Tagged.Tagged'.
 instance From.From a (Tagged.Tagged t a)
 
+-- | Uses @coerce@. Essentially the same as 'Tagged.unTagged'.
+instance From.From (Tagged.Tagged t a) a
+
 --
 
 realFloatToRational ::

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -20,6 +20,7 @@ import qualified Data.Map as Map
 import qualified Data.Ratio as Ratio
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
+import qualified Data.Tagged as Tagged
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Time as Time
@@ -2069,6 +2070,11 @@ spec = describe "Witch" $ do
       let f = Witch.from @Time.ZonedTime @Time.UTCTime
       it "works" $ do
         f (Time.ZonedTime (Time.LocalTime (Time.ModifiedJulianDay 0) (Time.TimeOfDay 0 0 0)) Time.utc) `shouldBe` Time.UTCTime (Time.ModifiedJulianDay 0) 0
+
+    describe "From a (Tagged t a)" $ do
+      let f = Witch.from @Bool @(Tagged.Tagged () Bool)
+      it "works" $ do
+        f False `shouldBe` Tagged.Tagged False
 
 newtype Age
   = Age Int.Int8

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -2076,6 +2076,11 @@ spec = describe "Witch" $ do
       it "works" $ do
         f False `shouldBe` Tagged.Tagged False
 
+    describe "From (Tagged t a) a" $ do
+      let f = Witch.from @(Tagged.Tagged () Bool) @Bool
+      it "works" $ do
+        f (Tagged.Tagged False) `shouldBe` False
+
 newtype Age
   = Age Int.Int8
   deriving (Eq, Show)

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -2080,6 +2081,11 @@ spec = describe "Witch" $ do
       let f = Witch.from @(Tagged.Tagged () Bool) @Bool
       it "works" $ do
         f (Tagged.Tagged False) `shouldBe` False
+
+    describe "From (Tagged t a) (Tagged u a)" $ do
+      let f = Witch.from @(Tagged.Tagged "old" Bool) @(Tagged.Tagged "new" Bool)
+      it "works" $ do
+        f (Tagged.Tagged False) `shouldBe` Tagged.Tagged False
 
 newtype Age
   = Age Int.Int8

--- a/witch.cabal
+++ b/witch.cabal
@@ -26,6 +26,7 @@ common library
     , base >= 4.10 && < 4.18
     , bytestring >= 0.10.8 && < 0.12
     , containers >= 0.5.10 && < 0.7
+    , tagged >= 0.8.6 && < 0.9
     , text >= 1.2.3 && < 1.3 || >= 2.0 && < 2.1
     , time >= 1.9.1 && < 1.13
   default-language: Haskell2010


### PR DESCRIPTION
This pull request adds three instances:

- `From a (Tagged t a)` for tagging values
- `From (Tagged t a) a` for untagging values
- `From (Tagged t a) (Tagged u a)` for retagging values

These changes were pulled out of #62. Although the won't directly address #56, they are related. 