### PR TITLE
Add instances for tagged UTF-8 conversions

### DIFF
--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
@@ -1042,6 +1043,10 @@ instance From.From ByteString.ByteString ShortByteString.ShortByteString where
 instance TryFrom.TryFrom ByteString.ByteString Text.Text where
   tryFrom = Utility.eitherTryFrom Text.decodeUtf8'
 
+-- | Uses 'Text.decodeUtf8''.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text where
+  tryFrom = Utility.eitherTryFrom $ Text.decodeUtf8' . From.from
+
 -- | Converts via 'Text.Text'.
 instance TryFrom.TryFrom ByteString.ByteString LazyText.Text where
   tryFrom =
@@ -1050,7 +1055,21 @@ instance TryFrom.TryFrom ByteString.ByteString LazyText.Text where
         . Utility.tryInto @Text.Text
 
 -- | Converts via 'Text.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) LazyText.Text where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @LazyText.Text)
+        . Utility.tryInto @Text.Text
+
+-- | Converts via 'Text.Text'.
 instance TryFrom.TryFrom ByteString.ByteString String where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @String)
+        . Utility.tryInto @Text.Text
+
+-- | Converts via 'Text.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) String where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @String)
@@ -1074,6 +1093,10 @@ instance From.From LazyByteString.ByteString ByteString.ByteString where
 instance TryFrom.TryFrom LazyByteString.ByteString LazyText.Text where
   tryFrom = Utility.eitherTryFrom LazyText.decodeUtf8'
 
+-- | Uses 'LazyText.decodeUtf8''.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyText.Text where
+  tryFrom = Utility.eitherTryFrom $ LazyText.decodeUtf8' . From.from
+
 -- | Converts via 'LazyText.Text'.
 instance TryFrom.TryFrom LazyByteString.ByteString Text.Text where
   tryFrom =
@@ -1082,7 +1105,21 @@ instance TryFrom.TryFrom LazyByteString.ByteString Text.Text where
         . Utility.tryInto @LazyText.Text
 
 -- | Converts via 'LazyText.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) Text.Text where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @Text.Text)
+        . Utility.tryInto @LazyText.Text
+
+-- | Converts via 'LazyText.Text'.
 instance TryFrom.TryFrom LazyByteString.ByteString String where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @String)
+        . Utility.tryInto @LazyText.Text
+
+-- | Converts via 'LazyText.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) String where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @String)
@@ -1112,9 +1149,17 @@ instance From.From Text.Text LazyText.Text where
 instance From.From Text.Text ByteString.ByteString where
   from = Text.encodeUtf8
 
+-- | Uses 'Text.encodeUtf8'.
+instance From.From Text.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = From.from . Text.encodeUtf8
+
 -- | Converts via 'ByteString.ByteString'.
 instance From.From Text.Text LazyByteString.ByteString where
   from = Utility.via @ByteString.ByteString
+
+-- | Converts via 'ByteString.ByteString'.
+instance From.From Text.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" ByteString.ByteString)
 
 -- LazyText
 
@@ -1126,9 +1171,17 @@ instance From.From LazyText.Text Text.Text where
 instance From.From LazyText.Text LazyByteString.ByteString where
   from = LazyText.encodeUtf8
 
+-- | Uses 'LazyText.encodeUtf8'.
+instance From.From LazyText.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+  from = From.from . LazyText.encodeUtf8
+
 -- | Converts via 'LazyByteString.ByteString'.
 instance From.From LazyText.Text ByteString.ByteString where
   from = Utility.via @LazyByteString.ByteString
+
+-- | Converts via 'LazyByteString.ByteString'.
+instance From.From LazyText.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
 
 -- String
 
@@ -1154,8 +1207,16 @@ instance From.From LazyText.Text String where
 instance From.From String ByteString.ByteString where
   from = Utility.via @Text.Text
 
+-- | Converts via 'Text.Text'.
+instance From.From String (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = Utility.via @Text.Text
+
 -- | Converts via 'LazyText.Text'.
 instance From.From String LazyByteString.ByteString where
+  from = Utility.via @LazyText.Text
+
+-- | Converts via 'LazyText.Text'.
+instance From.From String (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
   from = Utility.via @LazyText.Text
 
 -- TryFromException

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1807,6 +1807,13 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
         f (ByteString.pack [0xff]) `shouldBe` Nothing
 
+    describe "TryFrom ByteString Text" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
+      it "works" $ do
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
+
     describe "TryFrom ByteString LazyText" $ do
       let f = hush . Witch.tryFrom @ByteString.ByteString @LazyText.Text
       it "works" $ do
@@ -1814,12 +1821,26 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
         f (ByteString.pack [0xff]) `shouldBe` Nothing
 
+    describe "TryFrom ByteString LazyText" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
+      it "works" $ do
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
+
     describe "TryFrom ByteString String" $ do
       let f = hush . Witch.tryFrom @ByteString.ByteString @String
       it "works" $ do
         f (ByteString.pack []) `shouldBe` Just ""
         f (ByteString.pack [0x61]) `shouldBe` Just "a"
         f (ByteString.pack [0xff]) `shouldBe` Nothing
+
+    describe "TryFrom ByteString String" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
+      it "works" $ do
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just ""
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just "a"
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "From [Word8] LazyByteString" $ do
       let f = Witch.from @[Word.Word8] @LazyByteString.ByteString
@@ -1856,12 +1877,33 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
         f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
+    describe "TryFrom LazyByteString LazyText" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
+      it "works" $ do
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
+
+    describe "TryFrom LazyByteString Text" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @Text.Text
+      it "works" $ do
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
+
     describe "TryFrom LazyByteString String" $ do
       let f = hush . Witch.tryFrom @LazyByteString.ByteString @String
       it "works" $ do
         f (LazyByteString.pack []) `shouldBe` Just ""
         f (LazyByteString.pack [0x61]) `shouldBe` Just "a"
         f (LazyByteString.pack [0xff]) `shouldBe` Nothing
+
+    describe "TryFrom LazyByteString String" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
+      it "works" $ do
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just ""
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just "a"
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "From [Word8] ShortByteString" $ do
       let f = Witch.from @[Word.Word8] @ShortByteString.ShortByteString
@@ -1897,11 +1939,23 @@ spec = describe "Witch" $ do
         f (Text.pack "") `shouldBe` ByteString.pack []
         f (Text.pack "a") `shouldBe` ByteString.pack [0x61]
 
+    describe "From Text ByteString" $ do
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+
     describe "From Text LazyByteString" $ do
       let f = Witch.from @Text.Text @LazyByteString.ByteString
       it "works" $ do
         f (Text.pack "") `shouldBe` LazyByteString.pack []
         f (Text.pack "a") `shouldBe` LazyByteString.pack [0x61]
+
+    describe "From Text LazyByteString" $ do
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From LazyText Text" $ do
       let f = Witch.from @LazyText.Text @Text.Text
@@ -1916,11 +1970,23 @@ spec = describe "Witch" $ do
         f (LazyText.pack "") `shouldBe` LazyByteString.pack []
         f (LazyText.pack "a") `shouldBe` LazyByteString.pack [0x61]
 
+    describe "From LazyText LazyByteString" $ do
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+
     describe "From LazyText ByteString" $ do
       let f = Witch.from @LazyText.Text @ByteString.ByteString
       it "works" $ do
         f (LazyText.pack "") `shouldBe` ByteString.pack []
         f (LazyText.pack "a") `shouldBe` ByteString.pack [0x61]
+
+    describe "From LazyText ByteString" $ do
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From String Text" $ do
       let f = Witch.from @String @Text.Text
@@ -1956,11 +2022,23 @@ spec = describe "Witch" $ do
         f "" `shouldBe` ByteString.pack []
         f "a" `shouldBe` ByteString.pack [0x61]
 
+    describe "From String ByteString" $ do
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+
     describe "From String LazyByteString" $ do
       let f = Witch.from @String @LazyByteString.ByteString
       it "works" $ do
         f "" `shouldBe` LazyByteString.pack []
         f "a" `shouldBe` LazyByteString.pack [0x61]
+
+    describe "From String LazyByteString" $ do
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From Integer Day" $ do
       let f = Witch.from @Integer @Time.Day


### PR DESCRIPTION
This pull request adds a handful of new instances:

- `From Text (Tagged "UTF-8" ByteString)`
- `From Text (Tagged "UTF-8" LazyByteString)`
- `From LazyText (Tagged "UTF-8" ByteString)`
- `From LazyText (Tagged "UTF-8" LazyByteString)`
- `From String (Tagged "UTF-8" ByteString)`
- `From String (Tagged "UTF-8" LazyByteString)`
- `TryFrom (Tagged "UTF-8" ByteString) Text`
- `TryFrom (Tagged "UTF-8" ByteString) LazyText`
- `TryFrom (Tagged "UTF-8" ByteString) String`
- `TryFrom (Tagged "UTF-8" LazyByteString) Text`
- `TryFrom (Tagged "UTF-8" LazyByteString) LazyText`
- `TryFrom (Tagged "UTF-8" LazyByteString) String`

These instances all have existing counterparts that don't involve `Tagged`. Those existing instances will be deprecated and removed soon. 

These changes were pulled out of #62. They address part of #56, but not the whole thing.