### PR TITLE
Remove instances with untagged UTF-8 conversions

### DIFF
--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1040,32 +1040,14 @@ instance From.From ByteString.ByteString ShortByteString.ShortByteString where
   from = ShortByteString.toShort
 
 -- | Uses 'Text.decodeUtf8''.
-instance TryFrom.TryFrom ByteString.ByteString Text.Text where
-  tryFrom = Utility.eitherTryFrom Text.decodeUtf8'
-
--- | Uses 'Text.decodeUtf8''.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text where
   tryFrom = Utility.eitherTryFrom $ Text.decodeUtf8' . From.from
-
--- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString LazyText.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @LazyText.Text)
-        . Utility.tryInto @Text.Text
 
 -- | Converts via 'Text.Text'.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) LazyText.Text where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @LazyText.Text)
-        . Utility.tryInto @Text.Text
-
--- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom ByteString.ByteString String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
         . Utility.tryInto @Text.Text
 
 -- | Converts via 'Text.Text'.
@@ -1090,32 +1072,14 @@ instance From.From LazyByteString.ByteString ByteString.ByteString where
   from = LazyByteString.toStrict
 
 -- | Uses 'LazyText.decodeUtf8''.
-instance TryFrom.TryFrom LazyByteString.ByteString LazyText.Text where
-  tryFrom = Utility.eitherTryFrom LazyText.decodeUtf8'
-
--- | Uses 'LazyText.decodeUtf8''.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyText.Text where
   tryFrom = Utility.eitherTryFrom $ LazyText.decodeUtf8' . From.from
-
--- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString Text.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @Text.Text)
-        . Utility.tryInto @LazyText.Text
 
 -- | Converts via 'LazyText.Text'.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) Text.Text where
   tryFrom =
     Utility.eitherTryFrom $
       fmap (Utility.into @Text.Text)
-        . Utility.tryInto @LazyText.Text
-
--- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom LazyByteString.ByteString String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
         . Utility.tryInto @LazyText.Text
 
 -- | Converts via 'LazyText.Text'.
@@ -1146,16 +1110,8 @@ instance From.From Text.Text LazyText.Text where
   from = LazyText.fromStrict
 
 -- | Uses 'Text.encodeUtf8'.
-instance From.From Text.Text ByteString.ByteString where
-  from = Text.encodeUtf8
-
--- | Uses 'Text.encodeUtf8'.
 instance From.From Text.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
   from = From.from . Text.encodeUtf8
-
--- | Converts via 'ByteString.ByteString'.
-instance From.From Text.Text LazyByteString.ByteString where
-  from = Utility.via @ByteString.ByteString
 
 -- | Converts via 'ByteString.ByteString'.
 instance From.From Text.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
@@ -1168,16 +1124,8 @@ instance From.From LazyText.Text Text.Text where
   from = LazyText.toStrict
 
 -- | Uses 'LazyText.encodeUtf8'.
-instance From.From LazyText.Text LazyByteString.ByteString where
-  from = LazyText.encodeUtf8
-
--- | Uses 'LazyText.encodeUtf8'.
 instance From.From LazyText.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
   from = From.from . LazyText.encodeUtf8
-
--- | Converts via 'LazyByteString.ByteString'.
-instance From.From LazyText.Text ByteString.ByteString where
-  from = Utility.via @LazyByteString.ByteString
 
 -- | Converts via 'LazyByteString.ByteString'.
 instance From.From LazyText.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
@@ -1204,16 +1152,8 @@ instance From.From LazyText.Text String where
   from = LazyText.unpack
 
 -- | Converts via 'Text.Text'.
-instance From.From String ByteString.ByteString where
-  from = Utility.via @Text.Text
-
--- | Converts via 'Text.Text'.
 instance From.From String (Tagged.Tagged "UTF-8" ByteString.ByteString) where
   from = Utility.via @Text.Text
-
--- | Converts via 'LazyText.Text'.
-instance From.From String LazyByteString.ByteString where
-  from = Utility.via @LazyText.Text
 
 -- | Converts via 'LazyText.Text'.
 instance From.From String (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1801,13 +1801,6 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x0f, 0xf0]) `shouldBe` ShortByteString.pack [0x0f, 0xf0]
 
     describe "TryFrom ByteString Text" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @Text.Text
-      it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (ByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom ByteString Text" $ do
       let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
@@ -1815,25 +1808,11 @@ spec = describe "Witch" $ do
         f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom ByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @LazyText.Text
-      it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (ByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom ByteString LazyText" $ do
       let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (LazyText.pack "")
         f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
         f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
-
-    describe "TryFrom ByteString String" $ do
-      let f = hush . Witch.tryFrom @ByteString.ByteString @String
-      it "works" $ do
-        f (ByteString.pack []) `shouldBe` Just ""
-        f (ByteString.pack [0x61]) `shouldBe` Just "a"
-        f (ByteString.pack [0xff]) `shouldBe` Nothing
 
     describe "TryFrom ByteString String" $ do
       let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
@@ -1864,20 +1843,6 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack [0x0f, 0xf0]) `shouldBe` ByteString.pack [0x0f, 0xf0]
 
     describe "TryFrom LazyByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @LazyText.Text
-      it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just (LazyText.pack "")
-        f (LazyByteString.pack [0x61]) `shouldBe` Just (LazyText.pack "a")
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom LazyByteString Text" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @Text.Text
-      it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just (Text.pack "")
-        f (LazyByteString.pack [0x61]) `shouldBe` Just (Text.pack "a")
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
-
-    describe "TryFrom LazyByteString LazyText" $ do
       let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
       it "works" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (LazyText.pack "")
@@ -1890,13 +1855,6 @@ spec = describe "Witch" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (Text.pack "")
         f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
         f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
-
-    describe "TryFrom LazyByteString String" $ do
-      let f = hush . Witch.tryFrom @LazyByteString.ByteString @String
-      it "works" $ do
-        f (LazyByteString.pack []) `shouldBe` Just ""
-        f (LazyByteString.pack [0x61]) `shouldBe` Just "a"
-        f (LazyByteString.pack [0xff]) `shouldBe` Nothing
 
     describe "TryFrom LazyByteString String" $ do
       let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
@@ -1934,22 +1892,10 @@ spec = describe "Witch" $ do
         f (Text.pack "ab") `shouldBe` LazyText.pack "ab"
 
     describe "From Text ByteString" $ do
-      let f = Witch.from @Text.Text @ByteString.ByteString
-      it "works" $ do
-        f (Text.pack "") `shouldBe` ByteString.pack []
-        f (Text.pack "a") `shouldBe` ByteString.pack [0x61]
-
-    describe "From Text ByteString" $ do
       let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
       it "works" $ do
         f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
         f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
-
-    describe "From Text LazyByteString" $ do
-      let f = Witch.from @Text.Text @LazyByteString.ByteString
-      it "works" $ do
-        f (Text.pack "") `shouldBe` LazyByteString.pack []
-        f (Text.pack "a") `shouldBe` LazyByteString.pack [0x61]
 
     describe "From Text LazyByteString" $ do
       let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
@@ -1965,22 +1911,10 @@ spec = describe "Witch" $ do
         f (LazyText.pack "ab") `shouldBe` Text.pack "ab"
 
     describe "From LazyText LazyByteString" $ do
-      let f = Witch.from @LazyText.Text @LazyByteString.ByteString
-      it "works" $ do
-        f (LazyText.pack "") `shouldBe` LazyByteString.pack []
-        f (LazyText.pack "a") `shouldBe` LazyByteString.pack [0x61]
-
-    describe "From LazyText LazyByteString" $ do
       let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
         f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
-
-    describe "From LazyText ByteString" $ do
-      let f = Witch.from @LazyText.Text @ByteString.ByteString
-      it "works" $ do
-        f (LazyText.pack "") `shouldBe` ByteString.pack []
-        f (LazyText.pack "a") `shouldBe` ByteString.pack [0x61]
 
     describe "From LazyText ByteString" $ do
       let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
@@ -2017,22 +1951,10 @@ spec = describe "Witch" $ do
         f (LazyText.pack "ab") `shouldBe` "ab"
 
     describe "From String ByteString" $ do
-      let f = Witch.from @String @ByteString.ByteString
-      it "works" $ do
-        f "" `shouldBe` ByteString.pack []
-        f "a" `shouldBe` ByteString.pack [0x61]
-
-    describe "From String ByteString" $ do
       let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
       it "works" $ do
         f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
         f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
-
-    describe "From String LazyByteString" $ do
-      let f = Witch.from @String @LazyByteString.ByteString
-      it "works" $ do
-        f "" `shouldBe` LazyByteString.pack []
-        f "a" `shouldBe` LazyByteString.pack [0x61]
 
     describe "From String LazyByteString" $ do
       let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)


### PR DESCRIPTION
This pull request removes a handful of old instances:

- `From Text ByteString`
- `From Text LazyByteString`
- `From LazyText ByteString`
- `From LazyText LazyByteString`
- `From String ByteString`
- `From String LazyByteString`
- `TryFrom ByteString Text`
- `TryFrom ByteString LazyText`
- `TryFrom ByteString String`
- `TryFrom LazyByteString Text`
- `TryFrom LazyByteString LazyText`
- `TryFrom LazyByteString String`

These instances all have counterparts that involve `Tagged`. To upgrade, use the new `Tagged` instances. 

These changes were pulled out of #62 and are related to #64, which adds the new `Tagged` instances. This PR fixes #56. 