### PR TITLE
Add `Witch.Encoding.UTF_8`

### DIFF
--- a/source/library/Witch/Encoding.hs
+++ b/source/library/Witch/Encoding.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE DataKinds #-}
+
+module Witch.Encoding where
+
+import qualified Data.Tagged as Tagged
+
+-- | <https://en.wikipedia.org/wiki/UTF-8>
+type UTF_8 = Tagged.Tagged "UTF-8"

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
@@ -38,6 +37,7 @@ import qualified Data.Word as Word
 import qualified GHC.Float as Float
 import qualified Numeric
 import qualified Numeric.Natural as Natural
+import qualified Witch.Encoding as Encoding
 import qualified Witch.From as From
 import qualified Witch.TryFrom as TryFrom
 import qualified Witch.TryFromException as TryFromException
@@ -1229,51 +1229,51 @@ instance From.From (Tagged.Tagged t a) (Tagged.Tagged u a)
 -- UTF-8
 
 -- | Uses 'Text.decodeUtf8''.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text where
+instance TryFrom.TryFrom (Encoding.UTF_8 ByteString.ByteString) Text.Text where
   tryFrom = Utility.eitherTryFrom $ Text.decodeUtf8' . From.from
 
 -- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) LazyText.Text where
+instance TryFrom.TryFrom (Encoding.UTF_8 ByteString.ByteString) LazyText.Text where
   tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @LazyText.Text) . Utility.tryInto @Text.Text
 
 -- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) String where
+instance TryFrom.TryFrom (Encoding.UTF_8 ByteString.ByteString) String where
   tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @String) . Utility.tryInto @Text.Text
 
 -- | Uses 'LazyText.decodeUtf8''.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyText.Text where
+instance TryFrom.TryFrom (Encoding.UTF_8 LazyByteString.ByteString) LazyText.Text where
   tryFrom = Utility.eitherTryFrom $ LazyText.decodeUtf8' . From.from
 
 -- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) Text.Text where
+instance TryFrom.TryFrom (Encoding.UTF_8 LazyByteString.ByteString) Text.Text where
   tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @Text.Text) . Utility.tryInto @LazyText.Text
 
 -- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) String where
+instance TryFrom.TryFrom (Encoding.UTF_8 LazyByteString.ByteString) String where
   tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @String) . Utility.tryInto @LazyText.Text
 
 -- | Uses 'Text.encodeUtf8'.
-instance From.From Text.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+instance From.From Text.Text (Encoding.UTF_8 ByteString.ByteString) where
   from = From.from . Text.encodeUtf8
 
 -- | Converts via 'ByteString.ByteString'.
-instance From.From Text.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
-  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+instance From.From Text.Text (Encoding.UTF_8 LazyByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Encoding.UTF_8 ByteString.ByteString)
 
 -- | Uses 'LazyText.encodeUtf8'.
-instance From.From LazyText.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+instance From.From LazyText.Text (Encoding.UTF_8 LazyByteString.ByteString) where
   from = From.from . LazyText.encodeUtf8
 
 -- | Converts via 'LazyByteString.ByteString'.
-instance From.From LazyText.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
-  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+instance From.From LazyText.Text (Encoding.UTF_8 ByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Encoding.UTF_8 LazyByteString.ByteString)
 
 -- | Converts via 'Text.Text'.
-instance From.From String (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+instance From.From String (Encoding.UTF_8 ByteString.ByteString) where
   from = Utility.via @Text.Text
 
 -- | Converts via 'LazyText.Text'.
-instance From.From String (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+instance From.From String (Encoding.UTF_8 LazyByteString.ByteString) where
   from = Utility.via @LazyText.Text
 
 --

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1234,17 +1234,11 @@ instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text
 
 -- | Converts via 'Text.Text'.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) LazyText.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @LazyText.Text)
-        . Utility.tryInto @Text.Text
+  tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @LazyText.Text) . Utility.tryInto @Text.Text
 
 -- | Converts via 'Text.Text'.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
-        . Utility.tryInto @Text.Text
+  tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @String) . Utility.tryInto @Text.Text
 
 -- | Uses 'LazyText.decodeUtf8''.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyText.Text where
@@ -1252,17 +1246,11 @@ instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyT
 
 -- | Converts via 'LazyText.Text'.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) Text.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @Text.Text)
-        . Utility.tryInto @LazyText.Text
+  tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @Text.Text) . Utility.tryInto @LazyText.Text
 
 -- | Converts via 'LazyText.Text'.
 instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
-        . Utility.tryInto @LazyText.Text
+  tryFrom = Utility.eitherTryFrom $ fmap (Utility.into @String) . Utility.tryInto @LazyText.Text
 
 -- | Uses 'Text.encodeUtf8'.
 instance From.From Text.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1039,24 +1039,6 @@ instance From.From ByteString.ByteString LazyByteString.ByteString where
 instance From.From ByteString.ByteString ShortByteString.ShortByteString where
   from = ShortByteString.toShort
 
--- | Uses 'Text.decodeUtf8''.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text where
-  tryFrom = Utility.eitherTryFrom $ Text.decodeUtf8' . From.from
-
--- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) LazyText.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @LazyText.Text)
-        . Utility.tryInto @Text.Text
-
--- | Converts via 'Text.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
-        . Utility.tryInto @Text.Text
-
 -- LazyByteString
 
 -- | Uses 'LazyByteString.pack'.
@@ -1070,24 +1052,6 @@ instance From.From LazyByteString.ByteString [Word.Word8] where
 -- | Uses 'LazyByteString.toStrict'.
 instance From.From LazyByteString.ByteString ByteString.ByteString where
   from = LazyByteString.toStrict
-
--- | Uses 'LazyText.decodeUtf8''.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyText.Text where
-  tryFrom = Utility.eitherTryFrom $ LazyText.decodeUtf8' . From.from
-
--- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) Text.Text where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @Text.Text)
-        . Utility.tryInto @LazyText.Text
-
--- | Converts via 'LazyText.Text'.
-instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) String where
-  tryFrom =
-    Utility.eitherTryFrom $
-      fmap (Utility.into @String)
-        . Utility.tryInto @LazyText.Text
 
 -- ShortByteString
 
@@ -1109,27 +1073,11 @@ instance From.From ShortByteString.ShortByteString ByteString.ByteString where
 instance From.From Text.Text LazyText.Text where
   from = LazyText.fromStrict
 
--- | Uses 'Text.encodeUtf8'.
-instance From.From Text.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
-  from = From.from . Text.encodeUtf8
-
--- | Converts via 'ByteString.ByteString'.
-instance From.From Text.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
-  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" ByteString.ByteString)
-
 -- LazyText
 
 -- | Uses 'LazyText.toStrict'.
 instance From.From LazyText.Text Text.Text where
   from = LazyText.toStrict
-
--- | Uses 'LazyText.encodeUtf8'.
-instance From.From LazyText.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
-  from = From.from . LazyText.encodeUtf8
-
--- | Converts via 'LazyByteString.ByteString'.
-instance From.From LazyText.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
-  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
 
 -- String
 
@@ -1150,14 +1098,6 @@ instance From.From String LazyText.Text where
 -- | Uses 'LazyText.unpack'.
 instance From.From LazyText.Text String where
   from = LazyText.unpack
-
--- | Converts via 'Text.Text'.
-instance From.From String (Tagged.Tagged "UTF-8" ByteString.ByteString) where
-  from = Utility.via @Text.Text
-
--- | Converts via 'LazyText.Text'.
-instance From.From String (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
-  from = Utility.via @LazyText.Text
 
 -- TryFromException
 
@@ -1285,6 +1225,68 @@ instance From.From (Tagged.Tagged t a) a
 
 -- | Uses @coerce@. Essentially the same as 'Tagged.retag'.
 instance From.From (Tagged.Tagged t a) (Tagged.Tagged u a)
+
+-- UTF-8
+
+-- | Uses 'Text.decodeUtf8''.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) Text.Text where
+  tryFrom = Utility.eitherTryFrom $ Text.decodeUtf8' . From.from
+
+-- | Converts via 'Text.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) LazyText.Text where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @LazyText.Text)
+        . Utility.tryInto @Text.Text
+
+-- | Converts via 'Text.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" ByteString.ByteString) String where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @String)
+        . Utility.tryInto @Text.Text
+
+-- | Uses 'LazyText.decodeUtf8''.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) LazyText.Text where
+  tryFrom = Utility.eitherTryFrom $ LazyText.decodeUtf8' . From.from
+
+-- | Converts via 'LazyText.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) Text.Text where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @Text.Text)
+        . Utility.tryInto @LazyText.Text
+
+-- | Converts via 'LazyText.Text'.
+instance TryFrom.TryFrom (Tagged.Tagged "UTF-8" LazyByteString.ByteString) String where
+  tryFrom =
+    Utility.eitherTryFrom $
+      fmap (Utility.into @String)
+        . Utility.tryInto @LazyText.Text
+
+-- | Uses 'Text.encodeUtf8'.
+instance From.From Text.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = From.from . Text.encodeUtf8
+
+-- | Converts via 'ByteString.ByteString'.
+instance From.From Text.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+
+-- | Uses 'LazyText.encodeUtf8'.
+instance From.From LazyText.Text (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+  from = From.from . LazyText.encodeUtf8
+
+-- | Converts via 'LazyByteString.ByteString'.
+instance From.From LazyText.Text (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = fmap From.from . Utility.into @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+
+-- | Converts via 'Text.Text'.
+instance From.From String (Tagged.Tagged "UTF-8" ByteString.ByteString) where
+  from = Utility.via @Text.Text
+
+-- | Converts via 'LazyText.Text'.
+instance From.From String (Tagged.Tagged "UTF-8" LazyByteString.ByteString) where
+  from = Utility.via @LazyText.Text
 
 --
 

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1806,6 +1806,10 @@ spec = describe "Witch" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
         f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
         f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
+        f (Tagged.Tagged (ByteString.pack [0x24])) `shouldBe` Just (Text.pack "\x24")
+        f (Tagged.Tagged (ByteString.pack [0xc2, 0xa3])) `shouldBe` Just (Text.pack "\xa3")
+        f (Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])) `shouldBe` Just (Text.pack "\x20ac")
+        f (Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])) `shouldBe` Just (Text.pack "\x10348")
 
     describe "TryFrom ByteString LazyText" $ do
       let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
@@ -1896,6 +1900,10 @@ spec = describe "Witch" $ do
       it "works" $ do
         f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
         f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+        f (Text.pack "\x24") `shouldBe` Tagged.Tagged (ByteString.pack [0x24])
+        f (Text.pack "\xa3") `shouldBe` Tagged.Tagged (ByteString.pack [0xc2, 0xa3])
+        f (Text.pack "\x20ac") `shouldBe` Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])
+        f (Text.pack "\x10348") `shouldBe` Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])
 
     describe "From Text LazyByteString" $ do
       let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1800,31 +1800,6 @@ spec = describe "Witch" $ do
         f (ByteString.pack [0x00]) `shouldBe` ShortByteString.pack [0x00]
         f (ByteString.pack [0x0f, 0xf0]) `shouldBe` ShortByteString.pack [0x0f, 0xf0]
 
-    describe "TryFrom ByteString Text" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
-      it "works" $ do
-        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
-        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
-        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
-        f (Tagged.Tagged (ByteString.pack [0x24])) `shouldBe` Just (Text.pack "\x24")
-        f (Tagged.Tagged (ByteString.pack [0xc2, 0xa3])) `shouldBe` Just (Text.pack "\xa3")
-        f (Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])) `shouldBe` Just (Text.pack "\x20ac")
-        f (Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])) `shouldBe` Just (Text.pack "\x10348")
-
-    describe "TryFrom ByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
-      it "works" $ do
-        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (LazyText.pack "")
-        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
-        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
-
-    describe "TryFrom ByteString String" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
-      it "works" $ do
-        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just ""
-        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just "a"
-        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
-
     describe "From [Word8] LazyByteString" $ do
       let f = Witch.from @[Word.Word8] @LazyByteString.ByteString
       it "works" $ do
@@ -1845,27 +1820,6 @@ spec = describe "Witch" $ do
         f (LazyByteString.pack []) `shouldBe` ByteString.pack []
         f (LazyByteString.pack [0x00]) `shouldBe` ByteString.pack [0x00]
         f (LazyByteString.pack [0x0f, 0xf0]) `shouldBe` ByteString.pack [0x0f, 0xf0]
-
-    describe "TryFrom LazyByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
-      it "works" $ do
-        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (LazyText.pack "")
-        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
-        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
-
-    describe "TryFrom LazyByteString Text" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @Text.Text
-      it "works" $ do
-        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (Text.pack "")
-        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
-        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
-
-    describe "TryFrom LazyByteString String" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
-      it "works" $ do
-        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just ""
-        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just "a"
-        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "From [Word8] ShortByteString" $ do
       let f = Witch.from @[Word.Word8] @ShortByteString.ShortByteString
@@ -1895,40 +1849,12 @@ spec = describe "Witch" $ do
         f (Text.pack "a") `shouldBe` LazyText.pack "a"
         f (Text.pack "ab") `shouldBe` LazyText.pack "ab"
 
-    describe "From Text ByteString" $ do
-      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
-      it "works" $ do
-        f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
-        f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
-        f (Text.pack "\x24") `shouldBe` Tagged.Tagged (ByteString.pack [0x24])
-        f (Text.pack "\xa3") `shouldBe` Tagged.Tagged (ByteString.pack [0xc2, 0xa3])
-        f (Text.pack "\x20ac") `shouldBe` Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])
-        f (Text.pack "\x10348") `shouldBe` Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])
-
-    describe "From Text LazyByteString" $ do
-      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
-      it "works" $ do
-        f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
-        f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
-
     describe "From LazyText Text" $ do
       let f = Witch.from @LazyText.Text @Text.Text
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Text.pack ""
         f (LazyText.pack "a") `shouldBe` Text.pack "a"
         f (LazyText.pack "ab") `shouldBe` Text.pack "ab"
-
-    describe "From LazyText LazyByteString" $ do
-      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
-      it "works" $ do
-        f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
-        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
-
-    describe "From LazyText ByteString" $ do
-      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
-      it "works" $ do
-        f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
-        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From String Text" $ do
       let f = Witch.from @String @Text.Text
@@ -1957,18 +1883,6 @@ spec = describe "Witch" $ do
         f (LazyText.pack "") `shouldBe` ""
         f (LazyText.pack "a") `shouldBe` "a"
         f (LazyText.pack "ab") `shouldBe` "ab"
-
-    describe "From String ByteString" $ do
-      let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
-      it "works" $ do
-        f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
-        f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
-
-    describe "From String LazyByteString" $ do
-      let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
-      it "works" $ do
-        f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])
-        f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From Integer Day" $ do
       let f = Witch.from @Integer @Time.Day
@@ -2094,6 +2008,92 @@ spec = describe "Witch" $ do
       let f = Witch.from @(Tagged.Tagged "old" Bool) @(Tagged.Tagged "new" Bool)
       it "works" $ do
         f (Tagged.Tagged False) `shouldBe` Tagged.Tagged False
+
+    describe "TryFrom ByteString Text" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
+      it "works" $ do
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
+        f (Tagged.Tagged (ByteString.pack [0x24])) `shouldBe` Just (Text.pack "\x24")
+        f (Tagged.Tagged (ByteString.pack [0xc2, 0xa3])) `shouldBe` Just (Text.pack "\xa3")
+        f (Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])) `shouldBe` Just (Text.pack "\x20ac")
+        f (Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])) `shouldBe` Just (Text.pack "\x10348")
+
+    describe "TryFrom ByteString LazyText" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
+      it "works" $ do
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
+
+    describe "TryFrom ByteString String" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
+      it "works" $ do
+        f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just ""
+        f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just "a"
+        f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
+
+    describe "TryFrom LazyByteString LazyText" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
+      it "works" $ do
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (LazyText.pack "")
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
+
+    describe "TryFrom LazyByteString Text" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @Text.Text
+      it "works" $ do
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (Text.pack "")
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
+
+    describe "TryFrom LazyByteString String" $ do
+      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
+      it "works" $ do
+        f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just ""
+        f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just "a"
+        f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
+
+    describe "From Text ByteString" $ do
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+        f (Text.pack "\x24") `shouldBe` Tagged.Tagged (ByteString.pack [0x24])
+        f (Text.pack "\xa3") `shouldBe` Tagged.Tagged (ByteString.pack [0xc2, 0xa3])
+        f (Text.pack "\x20ac") `shouldBe` Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])
+        f (Text.pack "\x10348") `shouldBe` Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])
+
+    describe "From Text LazyByteString" $ do
+      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+
+    describe "From LazyText LazyByteString" $ do
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
+
+    describe "From LazyText ByteString" $ do
+      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+
+    describe "From String ByteString" $ do
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      it "works" $ do
+        f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
+
+    describe "From String LazyByteString" $ do
+      let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      it "works" $ do
+        f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])
+        f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
 newtype Age
   = Age Int.Int8

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -33,6 +33,7 @@ import qualified GHC.Stack as Stack
 import qualified Numeric.Natural as Natural
 import qualified Test.HUnit as HUnit
 import qualified Witch
+import qualified Witch.Encoding as Encoding
 
 main :: IO ()
 main = HUnit.runTestTTAndExit $ specToTest spec
@@ -2010,7 +2011,7 @@ spec = describe "Witch" $ do
         f (Tagged.Tagged False) `shouldBe` Tagged.Tagged False
 
     describe "TryFrom ByteString Text" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @Text.Text
+      let f = hush . Witch.tryFrom @(Encoding.UTF_8 ByteString.ByteString) @Text.Text
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
         f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
@@ -2021,42 +2022,42 @@ spec = describe "Witch" $ do
         f (Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])) `shouldBe` Just (Text.pack "\x10348")
 
     describe "TryFrom ByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @LazyText.Text
+      let f = hush . Witch.tryFrom @(Encoding.UTF_8 ByteString.ByteString) @LazyText.Text
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (LazyText.pack "")
         f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
         f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom ByteString String" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" ByteString.ByteString) @String
+      let f = hush . Witch.tryFrom @(Encoding.UTF_8 ByteString.ByteString) @String
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just ""
         f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just "a"
         f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom LazyByteString LazyText" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @LazyText.Text
+      let f = hush . Witch.tryFrom @(Encoding.UTF_8 LazyByteString.ByteString) @LazyText.Text
       it "works" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (LazyText.pack "")
         f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
         f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom LazyByteString Text" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @Text.Text
+      let f = hush . Witch.tryFrom @(Encoding.UTF_8 LazyByteString.ByteString) @Text.Text
       it "works" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (Text.pack "")
         f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
         f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "TryFrom LazyByteString String" $ do
-      let f = hush . Witch.tryFrom @(Tagged.Tagged "UTF-8" LazyByteString.ByteString) @String
+      let f = hush . Witch.tryFrom @(Encoding.UTF_8 LazyByteString.ByteString) @String
       it "works" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just ""
         f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just "a"
         f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
     describe "From Text ByteString" $ do
-      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      let f = Witch.from @Text.Text @(Encoding.UTF_8 ByteString.ByteString)
       it "works" $ do
         f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
         f (Text.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
@@ -2066,31 +2067,31 @@ spec = describe "Witch" $ do
         f (Text.pack "\x10348") `shouldBe` Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])
 
     describe "From Text LazyByteString" $ do
-      let f = Witch.from @Text.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      let f = Witch.from @Text.Text @(Encoding.UTF_8 LazyByteString.ByteString)
       it "works" $ do
         f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
         f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From LazyText LazyByteString" $ do
-      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      let f = Witch.from @LazyText.Text @(Encoding.UTF_8 LazyByteString.ByteString)
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
         f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
     describe "From LazyText ByteString" $ do
-      let f = Witch.from @LazyText.Text @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      let f = Witch.from @LazyText.Text @(Encoding.UTF_8 ByteString.ByteString)
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
         f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From String ByteString" $ do
-      let f = Witch.from @String @(Tagged.Tagged "UTF-8" ByteString.ByteString)
+      let f = Witch.from @String @(Encoding.UTF_8 ByteString.ByteString)
       it "works" $ do
         f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
         f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
     describe "From String LazyByteString" $ do
-      let f = Witch.from @String @(Tagged.Tagged "UTF-8" LazyByteString.ByteString)
+      let f = Witch.from @String @(Encoding.UTF_8 LazyByteString.ByteString)
       it "works" $ do
         f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])
         f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -2010,7 +2010,7 @@ spec = describe "Witch" $ do
       it "works" $ do
         f (Tagged.Tagged False) `shouldBe` Tagged.Tagged False
 
-    describe "TryFrom ByteString Text" $ do
+    describe "TryFrom (UTF_8 ByteString) Text" $ do
       let f = hush . Witch.tryFrom @(Encoding.UTF_8 ByteString.ByteString) @Text.Text
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (Text.pack "")
@@ -2021,42 +2021,42 @@ spec = describe "Witch" $ do
         f (Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])) `shouldBe` Just (Text.pack "\x20ac")
         f (Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])) `shouldBe` Just (Text.pack "\x10348")
 
-    describe "TryFrom ByteString LazyText" $ do
+    describe "TryFrom (UTF_8 ByteString) LazyText" $ do
       let f = hush . Witch.tryFrom @(Encoding.UTF_8 ByteString.ByteString) @LazyText.Text
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just (LazyText.pack "")
         f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
         f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
-    describe "TryFrom ByteString String" $ do
+    describe "TryFrom (UTF_8 ByteString) String" $ do
       let f = hush . Witch.tryFrom @(Encoding.UTF_8 ByteString.ByteString) @String
       it "works" $ do
         f (Tagged.Tagged (ByteString.pack [])) `shouldBe` Just ""
         f (Tagged.Tagged (ByteString.pack [0x61])) `shouldBe` Just "a"
         f (Tagged.Tagged (ByteString.pack [0xff])) `shouldBe` Nothing
 
-    describe "TryFrom LazyByteString LazyText" $ do
+    describe "TryFrom (UTF_8 LazyByteString) LazyText" $ do
       let f = hush . Witch.tryFrom @(Encoding.UTF_8 LazyByteString.ByteString) @LazyText.Text
       it "works" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (LazyText.pack "")
         f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (LazyText.pack "a")
         f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
-    describe "TryFrom LazyByteString Text" $ do
+    describe "TryFrom (UTF_8 LazyByteString) Text" $ do
       let f = hush . Witch.tryFrom @(Encoding.UTF_8 LazyByteString.ByteString) @Text.Text
       it "works" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just (Text.pack "")
         f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just (Text.pack "a")
         f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
-    describe "TryFrom LazyByteString String" $ do
+    describe "TryFrom (UTF_8 LazyByteString) String" $ do
       let f = hush . Witch.tryFrom @(Encoding.UTF_8 LazyByteString.ByteString) @String
       it "works" $ do
         f (Tagged.Tagged (LazyByteString.pack [])) `shouldBe` Just ""
         f (Tagged.Tagged (LazyByteString.pack [0x61])) `shouldBe` Just "a"
         f (Tagged.Tagged (LazyByteString.pack [0xff])) `shouldBe` Nothing
 
-    describe "From Text ByteString" $ do
+    describe "From Text (UTF_8 ByteString)" $ do
       let f = Witch.from @Text.Text @(Encoding.UTF_8 ByteString.ByteString)
       it "works" $ do
         f (Text.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
@@ -2066,31 +2066,31 @@ spec = describe "Witch" $ do
         f (Text.pack "\x20ac") `shouldBe` Tagged.Tagged (ByteString.pack [0xe2, 0x82, 0xac])
         f (Text.pack "\x10348") `shouldBe` Tagged.Tagged (ByteString.pack [0xf0, 0x90, 0x8d, 0x88])
 
-    describe "From Text LazyByteString" $ do
+    describe "From Text (UTF_8 LazyByteString)" $ do
       let f = Witch.from @Text.Text @(Encoding.UTF_8 LazyByteString.ByteString)
       it "works" $ do
         f (Text.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
         f (Text.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
-    describe "From LazyText LazyByteString" $ do
+    describe "From LazyText (UTF_8 LazyByteString)" $ do
       let f = Witch.from @LazyText.Text @(Encoding.UTF_8 LazyByteString.ByteString)
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Tagged.Tagged (LazyByteString.pack [])
         f (LazyText.pack "a") `shouldBe` Tagged.Tagged (LazyByteString.pack [0x61])
 
-    describe "From LazyText ByteString" $ do
+    describe "From LazyText (UTF_8 ByteString)" $ do
       let f = Witch.from @LazyText.Text @(Encoding.UTF_8 ByteString.ByteString)
       it "works" $ do
         f (LazyText.pack "") `shouldBe` Tagged.Tagged (ByteString.pack [])
         f (LazyText.pack "a") `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
-    describe "From String ByteString" $ do
+    describe "From String (UTF_8 ByteString)" $ do
       let f = Witch.from @String @(Encoding.UTF_8 ByteString.ByteString)
       it "works" $ do
         f "" `shouldBe` Tagged.Tagged (ByteString.pack [])
         f "a" `shouldBe` Tagged.Tagged (ByteString.pack [0x61])
 
-    describe "From String LazyByteString" $ do
+    describe "From String (UTF_8 LazyByteString)" $ do
       let f = Witch.from @String @(Encoding.UTF_8 LazyByteString.ByteString)
       it "works" $ do
         f "" `shouldBe` Tagged.Tagged (LazyByteString.pack [])

--- a/witch.cabal
+++ b/witch.cabal
@@ -76,6 +76,7 @@ library
     , template-haskell >= 2.12 && < 2.20
   exposed-modules:
     Witch
+    Witch.Encoding
     Witch.From
     Witch.Instances
     Witch.Lift


### PR DESCRIPTION
This is part of #66. It doesn't add a new encoding. Instead it makes it easier to support new encodings. The new `Witch.Encoding.UTF_8` type alias is meant to make it easier to talk about UTF-8 encoded byte strings.

``` hs
-- before
from @Text @(Tagged "UTF-8" ByteString) "..."

-- after
from @Text @(UTF_8 ByteString) "..."
```