### PR TITLE
doc change for From

### DIFF
--- a/source/library/Witch/From.hs
+++ b/source/library/Witch/From.hs
@@ -19,7 +19,7 @@ class From source target where
   -- > -- Avoid this:
   -- > from (x :: s)
   -- >
-  -- > -- Prefer this:
+  -- > -- Prefer this (using [@TypeApplications@](https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/exts/type_applications.html) language extension):
   -- > from @s x
   --
   -- The default implementation of this method simply calls 'Coerce.coerce',


### PR DESCRIPTION
This is what I wish was present in the documentation when I first went through it.  I had never seen `TypeApplications` used before, and this first example in the `From` documentation really hung me up.  Googling for `@` only reveals pattern binds which made no sense in this context.

PS: This library IS the greatest thing since sliced bread. ;)