### PR TITLE
Don't re-export `as` by default

### DIFF
--- a/source/library/Witch.hs
+++ b/source/library/Witch.hs
@@ -34,7 +34,6 @@ module Witch
     Witch.Encoding.UTF_32BE,
 
     -- * Utilities
-    Witch.Utility.as,
     Witch.Utility.over,
     Witch.Utility.via,
     Witch.Utility.tryVia,

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -34,6 +34,7 @@ import qualified Numeric.Natural as Natural
 import qualified Test.HUnit as HUnit
 import qualified Witch
 import qualified Witch.Encoding as Encoding
+import qualified Witch.Utility as Utility
 
 main :: IO ()
 main = HUnit.runTestTTAndExit $ specToTest spec
@@ -55,7 +56,7 @@ spec = describe "Witch" $ do
   describe "Utility" $ do
     describe "as" $ do
       it "works" $ do
-        Witch.as @Int.Int8 1 `shouldBe` 1
+        Utility.as @Int.Int8 1 `shouldBe` 1
 
     describe "into" $ do
       it "works" $ do


### PR DESCRIPTION
To continue using it, import it from `Witch.Utility`.

This addresses part of #77.