### PR TITLE
Add instance for converting between `Fixed` resolutions

### DIFF
--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -9,6 +9,7 @@ module Witch.Instances where
 
 import qualified Control.Exception as Exception
 import qualified Control.Monad as Monad
+import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Bits as Bits
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as Char8
@@ -951,6 +952,16 @@ instance From.From (Fixed.Fixed a) Integer where
 -- | Uses 'toRational'.
 instance (Fixed.HasResolution a) => From.From (Fixed.Fixed a) Rational where
   from = toRational
+
+-- | Converts via 'Rational'.
+instance
+  (Fixed.HasResolution s, Fixed.HasResolution t) =>
+  TryFrom.TryFrom (Fixed.Fixed s) (Fixed.Fixed t)
+  where
+  tryFrom s =
+    Bifunctor.first (Utility.withSource s)
+      . TryFrom.tryFrom @Rational
+      $ From.from s
 
 -- Complex
 


### PR DESCRIPTION
I created this in response to #121, but it doesn't directly address that. Instead of changing the conversions between `Integer`s and `Fixed` values, I introduced a new instance for converting between `Fixed` values of different resolutions. For example:

``` hs
-- type Centi = Fixed E2 -- 0.12
-- type Milli = Fixed E3 -- 0.123

-- this will always succeed
-- (it might be interesting to write a `From` instance leveraging `Nat`s)
ghci> unsafeFrom @Centi @Milli 1.23
1.230

-- this particular conversion will succeed because it does not lose precision
ghc> unsafeFrom @Milli @Centi 1.23
1.23

-- but this one will fail because it loses precision
ghci> unsafeFrom @Milli @Centi 1.234
*** Exception: TryFromException @(Fixed * E3) @(Fixed * E2) 1.234 (Just loss of precision)
```

This is an interesting instance because `type Uni = Fixed E0` is isomorphic to `Integer`. So how does this instance compare to the existing instances?

``` hs
ghci> from @Integer @Centi 123
1.23
ghci> unsafeFrom @Uni @Centi 123
123.00

ghci> from @Centi @Integer 123
12300
ghci> unsafeFrom @Centi @Uni 123
123.0

-- don't be fooled by the ".0", it's always there
ghci> MkFixed 123 :: Uni
123.0
```

So this instance suggests that the `Integer` instances should behave the same way. 