### PR TITLE
Change conversions between `Integer` and `Fixed`

### DIFF
--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -939,15 +939,16 @@ instance (Fixed.HasResolution a) => TryFrom.TryFrom Rational (Fixed.Fixed a) whe
 
 -- Fixed
 
--- | Uses 'Fixed.MkFixed'. This means @from \@Integer \@Centi 2@ is @0.02@
--- rather than @2.00@.
-instance From.From Integer (Fixed.Fixed a) where
-  from = Fixed.MkFixed
+-- | Uses 'fromInteger'. This means @from \@Integer \@Centi 2@ is @02.00@
+-- rather than @0.02@.
+instance (Fixed.HasResolution a) => From.From Integer (Fixed.Fixed a) where
+  from = fromInteger
 
--- | Uses 'Fixed.MkFixed'. This means @from \@Centi \@Integer 3.00@ is @300@
--- rather than @3@.
-instance From.From (Fixed.Fixed a) Integer where
-  from (Fixed.MkFixed t) = t
+-- | Converts via 'Rational' when there is no fractional part. This means
+-- @tryFrom \@Centi \@Integer 2.00@ is @Right 2@ and
+-- @tryFrom \@Centi \@Integer 0.02@ will fail.
+instance (Fixed.HasResolution a) => TryFrom.TryFrom (Fixed.Fixed a) Integer where
+  tryFrom = Utility.eitherTryFrom $ TryFrom.tryFrom @Rational . From.from
 
 -- | Uses 'toRational'.
 instance (Fixed.HasResolution a) => From.From (Fixed.Fixed a) Rational where

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1663,16 +1663,16 @@ spec = describe "Witch" $ do
     describe "From Integer (Fixed a)" $ do
       let f = Witch.from @Integer @Fixed.Deci
       it "works" $ do
-        f 1 `shouldBe` 0.1
-        f 10 `shouldBe` 1
-        f 120 `shouldBe` 12
+        f 1 `shouldBe` 1.0
+        f 10 `shouldBe` 10.0
+        f 120 `shouldBe` 120.0
 
-    describe "From (Fixed a) Integer" $ do
-      let f = Witch.from @Fixed.Deci @Integer
+    describe "TryFrom (Fixed a) Integer" $ do
+      let f = hush . Witch.tryFrom @Fixed.Deci @Integer
       it "works" $ do
-        f 0.1 `shouldBe` 1
-        f 1 `shouldBe` 10
-        f 12 `shouldBe` 120
+        f 0.1 `shouldBe` Nothing
+        f 1 `shouldBe` Just 1
+        f 12 `shouldBe` Just 12
 
     describe "From (Fixed a) Rational" $ do
       let f = Witch.from @Fixed.Deci @Rational


### PR DESCRIPTION
Fixes #121.

Converting from an `Integer` into a `Fixed` type will now use `fromIntegral` rather than `MkFixed`. This means that the result will have no fractional part. This is a change in behavior. 

``` hs
-- before
ghci> from @Integer @Centi 123
1.23

-- after
ghci> from @Integer @Centi 123 
123.00
```

Converting from a `Fixed` type into an `Integer` will now go through `Rational` when there is no fractional part. This means that the conversion can fail. This is a change in behavior.

``` hs
-- before
ghci> from @Centi @Integer 123
12300

-- after
ghci> unsafeFrom @Centi @Integer 123
123
ghci> unsafeFrom @Centi @Integer 1.23
*** Exception: TryFromException @(Fixed * E2) @Integer 1.23 (Just (TryFromException @(Ratio Integer) @Integer (123 % 100) (Just loss of precision)))
```

These changes are motivated by the new instances added in #122. Now converting between `Integer` and `Fixed a` behaves the same as converting between `Uni` (aka `Fixed E0`, `Fixed 1`) and `Fixed a`. 

``` hs
ghci> unsafeFrom @Uni @Centi 123
123.00
ghci> unsafeFrom @Centi @Uni 123
123.0
```