### PR TITLE
Remove `OsChar` <-> `Char` instances

### DIFF
--- a/source/hedgehog/Main.hs
+++ b/source/hedgehog/Main.hs
@@ -1001,11 +1001,6 @@ groupOsString = group "OsString" $ do
     let t = Typeable.Proxy :: Typeable.Proxy [OsString.OsChar]
     fromFrom s t genOsString
 
-  property "OsChar" $ do
-    let s = Typeable.Proxy :: Typeable.Proxy Char
-    let t = Typeable.Proxy :: Typeable.Proxy OsString.OsChar
-    tryFromFrom s t Gen.ascii
-
   property "OsChar/Word" $ do
     let s = Typeable.Proxy :: Typeable.Proxy Word
     let t = Typeable.Proxy :: Typeable.Proxy OsString.OsChar

--- a/source/library/Witch/Instances.hs
+++ b/source/library/Witch/Instances.hs
@@ -1175,37 +1175,8 @@ instance From.From [OsString.OsChar] OsString.OsString where
 instance From.From OsString.OsString [OsString.OsChar] where
   from = OsString.unpack
 
--- | Uses 'OsString.unsafeFromChar'. Fails when the 'Char' does not fit in an
--- 'OsString.OsChar', which holds one byte on POSIX (code points above @0xFF@)
--- and two bytes on Windows (code points above @0xFFFF@). Guarded by a round
--- trip through 'OsString.toChar', so it never silently truncates.
---
--- An 'OsString.OsChar' is a single code unit in a platform encoding, not a
--- character; even the @os-string@ documentation notes it should perhaps have
--- been named @OsWord@. Treating it as a 'Char' is usually a mistake, since a
--- Unicode code point may span several code units. Prefer the
--- @'TryFrom.TryFrom' 'Word' 'OsString.OsChar'@ instance, which makes the code
--- unit explicit.
-instance TryFrom.TryFrom Char OsString.OsChar where
-  tryFrom =
-    Utility.maybeTryFrom $ \c ->
-      let oc = OsString.unsafeFromChar c
-       in if OsString.toChar oc == c then Just oc else Nothing
-
--- | Uses 'OsString.toChar'. Total because every 'OsString.OsChar' is a valid
--- Unicode code point.
---
--- Be wary of this conversion: an 'OsString.OsChar' is a single code unit in a
--- platform encoding rather than a character, so reinterpreting it as a 'Char'
--- produces a meaningful code point only for single-unit values. Prefer the
--- @'From.From' 'OsString.OsChar' 'Word'@ instance, which exposes the code unit
--- without pretending it is a character.
-instance From.From OsString.OsChar Char where
-  from = OsString.toChar
-
--- | Exposes the underlying code unit of an 'OsString.OsChar' as a 'Word'. Total
--- because an 'OsString.OsChar' is a single code unit (one byte on POSIX, two on
--- Windows), which always fits in a 'Word'.
+-- | Uses 'OsString.toChar'. Total because an 'OsString.OsChar' is a single code
+-- unit, which always fits in a 'Word'.
 instance From.From OsString.OsChar Word where
   from = fromIntegral . Char.ord . OsString.toChar
 

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1868,12 +1868,6 @@ spec = describe "Witch" $ do
         f (OsString.pack [OsString.unsafeFromChar 'a', OsString.unsafeFromChar 'b'])
           `shouldBe` [OsString.unsafeFromChar 'a', OsString.unsafeFromChar 'b']
 
-    describe "From OsChar Char" $ do
-      let f = Witch.from @OsString.OsChar @Char
-      it "works" $ do
-        f (OsString.unsafeFromChar 'a') `shouldBe` 'a'
-        f (OsString.unsafeFromChar '\xFF') `shouldBe` '\xFF'
-
     describe "From OsChar Word" $ do
       let f = Witch.from @OsString.OsChar @Word
       it "works" $ do
@@ -2486,14 +2480,6 @@ spec = describe "Witch" $ do
       let f = Witch.from @String @Encoding.Utf32BL
       it "works" $ do
         f "a" `shouldBe` Tagged.Tagged (LazyByteString.pack [0x00, 0x00, 0x00, 0x61])
-
-    describe "TryFrom Char OsChar" $ do
-      let f = hush . Witch.tryFrom @Char @OsString.OsChar
-      it "works" $ do
-        f 'a' `shouldBe` Just (OsString.unsafeFromChar 'a')
-        f '\xFF' `shouldBe` Just (OsString.unsafeFromChar '\xFF')
-        -- Above @0xFFFF@, so it fails on both POSIX and Windows.
-        f '\x10000' `shouldBe` Nothing
 
     describe "TryFrom Word OsChar" $ do
       let f = hush . Witch.tryFrom @Word @OsString.OsChar


### PR DESCRIPTION
Treating an `OsChar` as a `Char` is usually a mistake, since an `OsChar` is a single code unit in a platform encoding rather than a character. Use the `OsChar` <-> `Word` instances to work with code units explicitly.